### PR TITLE
Implementation for global Tate and Weierstrass models over specific toric base 3-folds

### DIFF
--- a/docs/doc.main
+++ b/docs/doc.main
@@ -4,5 +4,6 @@
    "FtheoryTools" => [
       "FTheoryTools/Introduction.md"
       "FTheoryTools/Weierstrass.md"
+      "FTheoryTools/Tate.md"
    ],
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(
     pages = ["index.md",
             "FTheoryTools/Introduction.md",
             "Tools" => ["FTheoryTools/Weierstrass.md"],
+            "Tools" => ["FTheoryTools/Tate.md"],
             ]
     )
 

--- a/docs/src/FTheoryTools/Introduction.md
+++ b/docs/src/FTheoryTools/Introduction.md
@@ -71,6 +71,9 @@ For detailed information about the implemented functionality, please take a look
 ## Bugs and feature requests
 
 If you want to report a bug or request a feature, please do it by raising a [github issue](https://github.com/Julia-meets-String-Theory/FTheoryTools.jl/issues).
+```@docs
+FTheoryTools.version
+```
 
 
 ## Contributions

--- a/docs/src/FTheoryTools/Tate.md
+++ b/docs/src/FTheoryTools/Tate.md
@@ -1,0 +1,50 @@
+```@meta
+CurrentModule = FTheoryTools
+```
+
+```@contents
+Pages = ["Tate.md"]
+```
+
+# Global Tate models
+
+A global Tate model describes a particular form of an elliptic fibration.
+We focus on elliptic fibraitons over base 3-folds ``B3``. Consider
+the weighted projective space ``\mathbb{P}_{2,3,1}`` with coordinates
+``x, y, z``. In addition, consider
+- ``a_1 \in H^0( B_3, \overline{K}_{B_3} )``,
+- ``a_2 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 2} )``,
+- ``a_3 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 3} )``,
+- ``a_4 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
+- ``a_6 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``.
+Then form a ``\mathbb{P}_{2,3,1}``-bundle over ``B3`` such that
+- ``x`` transforms as sections of ``2 \overline{K}_{B_3}``,
+- ``y`` transforms as sections of ``3 \overline{K}_{B_3}``,
+- ``z`` transforms as sections of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
+In this 5-fold ambient space, a global Tate model is the hypersurface defined
+by the vanishing of the Tate polynomial
+``P_T = x^3 - y^2 + x y z a_1 + x^2 z^2 a_2 + y z^3 a_3 + x z^4 a_4 + z^6 a_6``.
+For such geometries, we support functionality.
+
+
+## Constructors
+
+```@docs
+GenericGlobalTateModel(base::Oscar.AbstractNormalToricVariety)
+GenericGlobalTateModelOverProjectiveSpace()
+SpecificGlobalTateModel(ais::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}, base::Oscar.AbstractNormalToricVariety)
+```
+
+
+## Attributes
+
+```@docs
+a1(t::GlobalTateModel)
+a2(t::GlobalTateModel)
+a3(t::GlobalTateModel)
+a4(t::GlobalTateModel)
+a6(t::GlobalTateModel)
+pt(t::GlobalTateModel)
+toric_base_space(t::GlobalTateModel)
+toric_ambient_space(t::GlobalTateModel)
+```

--- a/docs/src/FTheoryTools/Tate.md
+++ b/docs/src/FTheoryTools/Tate.md
@@ -9,21 +9,21 @@ Pages = ["Tate.md"]
 # Global Tate models
 
 A global Tate model describes a particular form of an elliptic fibration.
-We focus on elliptic fibraitons over base 3-folds ``B3``. Consider
-the weighted projective space ``\mathbb{P}_{2,3,1}`` with coordinates
+We focus on elliptic fibrations over base 3-folds ``B3``. Consider
+the weighted projective space ``\mathbb{P}^{2,3,1}`` with coordinates
 ``x, y, z``. In addition, consider
 - ``a_1 \in H^0( B_3, \overline{K}_{B_3} )``,
 - ``a_2 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 2} )``,
 - ``a_3 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 3} )``,
 - ``a_4 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
 - ``a_6 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``.
-Then form a ``\mathbb{P}_{2,3,1}``-bundle over ``B3`` such that
-- ``x`` transforms as sections of ``2 \overline{K}_{B_3}``,
-- ``y`` transforms as sections of ``3 \overline{K}_{B_3}``,
-- ``z`` transforms as sections of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
+Then form a ``\mathbb{P}^{2,3,1}``-bundle over ``B3`` such that
+- ``x`` transforms as a section of ``2 \overline{K}_{B_3}``,
+- ``y`` transforms as a section of ``3 \overline{K}_{B_3}``,
+- ``z`` transforms as a section of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
 In this 5-fold ambient space, a global Tate model is the hypersurface defined
 by the vanishing of the Tate polynomial
-``P_T = x^3 - y^2 + x y z a_1 + x^2 z^2 a_2 + y z^3 a_3 + x z^4 a_4 + z^6 a_6``.
+``P_T = x^3 - y^2 - x y z a_1 + x^2 z^2 a_2 - y z^3 a_3 + x z^4 a_4 + z^6 a_6``.
 For such geometries, we support functionality.
 
 

--- a/docs/src/FTheoryTools/Weierstrass.md
+++ b/docs/src/FTheoryTools/Weierstrass.md
@@ -12,7 +12,7 @@ Pages = ["Weierstrass.md"]
 
 We support the following constructors:
 ```@docs
-GlobalWeierstrassModel(polys::Vector{MPolyElem{fmpq}})
+GlobalWeierstrassModel(polys::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
 GenericGlobalWeierstrassModelOverToricSpace(v::Oscar.AbstractNormalToricVariety)
 GenericGlobalWeierstrassModelOverProjectiveSpace(n::Int)
 ```

--- a/docs/src/FTheoryTools/Weierstrass.md
+++ b/docs/src/FTheoryTools/Weierstrass.md
@@ -8,13 +8,27 @@ Pages = ["Weierstrass.md"]
 
 # Global Weierstrass models
 
+A global Weierstrass model describes a particular form of an elliptic fibration.
+We focus on elliptic fibraitons over base 3-folds ``B3``. Consider
+the weighted projective space ``\mathbb{P}_{2,3,1}`` with coordinates
+``x, y, z``. In addition, consider
+- ``f \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
+- ``g \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``,
+Then form a ``\mathbb{P}_{2,3,1}``-bundle over ``B3`` such that
+- ``x`` transforms as sections of ``2 \overline{K}_{B_3}``,
+- ``y`` transforms as sections of ``3 \overline{K}_{B_3}``,
+- ``z`` transforms as sections of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
+In this 5-fold ambient space, a global Weierstrass model is the hypersurface defined
+by the vanishing of the Weierstrass polynomial ``P_W = x^3 - y^2 + f x z^4 + g z^6``.
+For such geometries, we support functionality.
+
 ## Constructors
 
 We support the following constructors:
 ```@docs
-GlobalWeierstrassModel(polys::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
-GenericGlobalWeierstrassModelOverToricSpace(v::Oscar.AbstractNormalToricVariety)
-GenericGlobalWeierstrassModelOverProjectiveSpace(n::Int)
+GenericGlobalWeierstrassModel(base::Oscar.AbstractNormalToricVariety)
+GenericGlobalWeierstrassModelOverProjectiveSpace()
+SpecificGlobalWeierstrassModel(f::MPolyElem_dec{fmpq, fmpq_mpoly}, g::MPolyElem_dec{fmpq, fmpq_mpoly}, base::Oscar.AbstractNormalToricVariety)
 ```
 
 ## Attributes
@@ -22,5 +36,7 @@ GenericGlobalWeierstrassModelOverProjectiveSpace(n::Int)
 ```@docs
 poly_f(w::GlobalWeierstrassModel)
 poly_g(w::GlobalWeierstrassModel)
+pw(w::GlobalWeierstrassModel)
 toric_base_space(w::GlobalWeierstrassModel)
+toric_ambient_space(w::GlobalWeierstrassModel)
 ```

--- a/docs/src/FTheoryTools/Weierstrass.md
+++ b/docs/src/FTheoryTools/Weierstrass.md
@@ -9,15 +9,15 @@ Pages = ["Weierstrass.md"]
 # Global Weierstrass models
 
 A global Weierstrass model describes a particular form of an elliptic fibration.
-We focus on elliptic fibraitons over base 3-folds ``B3``. Consider
-the weighted projective space ``\mathbb{P}_{2,3,1}`` with coordinates
+We focus on elliptic fibrations over base 3-folds ``B3``. Consider
+the weighted projective space ``\mathbb{P}^{2,3,1}`` with coordinates
 ``x, y, z``. In addition, consider
 - ``f \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
 - ``g \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``,
-Then form a ``\mathbb{P}_{2,3,1}``-bundle over ``B3`` such that
-- ``x`` transforms as sections of ``2 \overline{K}_{B_3}``,
-- ``y`` transforms as sections of ``3 \overline{K}_{B_3}``,
-- ``z`` transforms as sections of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
+Then form a ``\mathbb{P}^{2,3,1}``-bundle over ``B3`` such that
+- ``x`` transforms as a section of ``2 \overline{K}_{B_3}``,
+- ``y`` transforms as a section of ``3 \overline{K}_{B_3}``,
+- ``z`` transforms as a section of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
 In this 5-fold ambient space, a global Weierstrass model is the hypersurface defined
 by the vanishing of the Weierstrass polynomial ``P_W = x^3 - y^2 + f x z^4 + g z^6``.
 For such geometries, we support functionality.

--- a/src/FTheoryTools.jl
+++ b/src/FTheoryTools.jl
@@ -31,4 +31,8 @@ const version = IS_DEV ? VersionNumber("$(VERSION_NUMBER)-dev") : VERSION_NUMBER
 include("WeierstrassModels/constructors.jl")
 include("WeierstrassModels/attributes.jl")
 
+# include files
+include("TateModels/constructors.jl")
+include("TateModels/attributes.jl")
+
 end

--- a/src/TateModels/attributes.jl
+++ b/src/TateModels/attributes.jl
@@ -1,0 +1,255 @@
+#######################################
+# 1: The Tate sections
+#######################################
+
+@doc Markdown.doc"""
+    a1(t::GlobalTateModel)
+
+Return the Tate section ``a_1``.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> a1(t);
+```
+"""
+@attr MPolyElem{fmpq} a1(t::GlobalTateModel) = t.a1
+export a1
+
+
+@doc Markdown.doc"""
+    a2(t::GlobalTateModel)
+
+Return the Tate section ``a_2``.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> a2(t);
+```
+"""
+@attr MPolyElem{fmpq} a2(t::GlobalTateModel) = t.a2
+export a2
+
+
+@doc Markdown.doc"""
+    a3(t::GlobalTateModel)
+
+Return the Tate section ``a_3``.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> a3(t);
+```
+"""
+@attr MPolyElem{fmpq} a3(t::GlobalTateModel) = t.a3
+export a3
+
+
+@doc Markdown.doc"""
+    a4(t::GlobalTateModel)
+
+Return the Tate section ``a_4``.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> a4(t);
+```
+"""
+@attr MPolyElem{fmpq} a4(t::GlobalTateModel) = t.a4
+export a4
+
+
+@doc Markdown.doc"""
+    a6(t::GlobalTateModel)
+
+Return the Tate section ``a_6``.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> a6(t);
+```
+"""
+@attr MPolyElem{fmpq} a6(t::GlobalTateModel) = t.a6
+export a6
+
+
+#######################################
+# 2: The Tate polynomial
+#######################################
+
+@doc Markdown.doc"""
+    pt(t::GlobalTateModel)
+
+Return the Tate polynomial of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> pt(t);
+```
+"""
+@attr MPolyElem{fmpq} pt(t::GlobalTateModel) = t.pt
+export pt
+
+
+#######################################
+# 3: Toric spaces
+#######################################
+
+@doc Markdown.doc"""
+    toric_base_space(t::GlobalTateModel)
+
+Return the toric base space of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> toric_base_space(t)
+A normal, 3-dimensional toric variety without torusfactor
+```
+"""
+@attr Oscar.AbstractNormalToricVariety toric_base_space(t::GlobalTateModel) = t.base
+export toric_base_space
+
+
+@doc Markdown.doc"""
+    toric_ambient_space(t::GlobalTateModel)
+
+Return the toric ambient space of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> toric_ambient_space(t)
+A normal toric variety
+
+julia> is_smooth(toric_ambient_space(t))
+false
+```
+"""
+@attr Oscar.AbstractNormalToricVariety toric_ambient_space(t::GlobalTateModel) = t.toric_ambient_space
+export toric_ambient_space

--- a/src/TateModels/constructors.jl
+++ b/src/TateModels/constructors.jl
@@ -128,7 +128,7 @@ function GenericGlobalTateModel(base::Oscar.AbstractNormalToricVariety)
     x = gens(S2)[length(gens(S2))-2]
     y = gens(S2)[length(gens(S2))-1]
     z = gens(S2)[length(gens(S2))]
-    pt = x^3 - y^2 + x*y*z*a1 + x^2*z^2*a2 + y*z^3*a3 + x*z^4*a4 + z^6*a6
+    pt = x^3 - y^2 - x*y*z*a1 + x^2*z^2*a2 - y*z^3*a3 + x*z^4*a4 + z^6*a6
 
     # TODO: Compute the toric hypersurface
     # TODO: Once new Oscar release is available
@@ -247,7 +247,7 @@ function SpecificGlobalTateModel(ais::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}, b
     y = gens(S2)[length(gens(S2))-1]
     z = gens(S2)[length(gens(S2))]
     ring_map = hom(S1, S2, [gens(S2)[i] for i in 1:length(gens(S1))])
-    pt = x^3 - y^2 + x*y*z*ring_map(ais[1]) + x^2*z^2*ring_map(ais[2]) + y*z^3*ring_map(ais[3]) + x*z^4*ring_map(ais[4]) + z^6*ring_map(ais[5])
+    pt = x^3 - y^2 - x*y*z*ring_map(ais[1]) + x^2*z^2*ring_map(ais[2]) - y*z^3*ring_map(ais[3]) + x*z^4*ring_map(ais[4]) + z^6*ring_map(ais[5])
 
     # TODO: Compute the toric hypersurface
     # TODO: Once new Oscar release is available

--- a/src/TateModels/constructors.jl
+++ b/src/TateModels/constructors.jl
@@ -1,0 +1,269 @@
+##############################################
+# 1: The Julia type for GlobalTateModel
+##############################################
+
+@attributes mutable struct GlobalTateModel
+    a1::MPolyElem{fmpq}
+    a2::MPolyElem{fmpq}
+    a3::MPolyElem{fmpq}
+    a4::MPolyElem{fmpq}
+    a6::MPolyElem{fmpq}
+    pt::MPolyElem{fmpq}
+    base::Oscar.AbstractNormalToricVariety
+    toric_ambient_space::Oscar.AbstractNormalToricVariety
+    # TODO: Once new Oscar release is available
+    #Y4::Oscar.ClosedSubvarietyOfToricVariety
+    function GlobalTateModel(a1::MPolyElem{fmpq},
+                             a2::MPolyElem{fmpq},
+                             a3::MPolyElem{fmpq},
+                             a4::MPolyElem{fmpq},
+                             a6::MPolyElem{fmpq},
+                             pt::MPolyElem{fmpq},
+                             base::Oscar.AbstractNormalToricVariety,
+                             toric_ambient_space::Oscar.AbstractNormalToricVariety)
+                             # TODO: Once new Oscar release is available
+                             #Y4::Oscar.ClosedSubvarietyOfToricVariety)
+        return new(a1, a2, a3, a4, a6, pt, base, toric_ambient_space)
+    end
+end
+export GlobalTateModel
+
+
+#######################################
+# 2: Generic constructor
+#######################################
+
+@doc Markdown.doc"""
+    GenericGlobalTateModel(base::Oscar.AbstractNormalToricVariety)
+
+This method constructs a global Tate model over a given toric base
+3-fold. The Tate sections ``a_i`` are taken with (pseudo) random coefficients.
+
+One way to achieve this is to first focus on the Cox ring of the toric
+ambient space. This ring must be graded such that the Tate polynomial is
+homogeneous and cuts out a Calabi-Yau hypersurface. Given this grading,
+one can perform a triangulation. This triangulation will typically
+take a long time to complete and yield a large number of candidate ambient
+spaces. Typically, one wishes to focus on those spaces which contain the
+base toric space in a manifest way. But even this criterion usually
+allows for many ambient spaces.
+
+This method here operates in the opposite way. It begins by extracting the rays and
+maximal cones of the base space. Subsequently, those rays and cones are extended
+to form one of the many toric 5-fold ambient spaces. The following example
+demonstrates that this ambient space of a (singular) global Tate model need
+not be smooth.
+
+# Examples
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> t = GenericGlobalTateModel(base)
+A global Tate model
+
+julia> is_smooth(toric_ambient_space(t))
+false
+```
+"""
+function GenericGlobalTateModel(base::Oscar.AbstractNormalToricVariety)
+
+    # Check if the base space is 3-dimensional
+    if dim(base) != 3
+        throw(ArgumentError("We currently focus on global Tate models over 3-dimensional toric base spaces"))
+    end
+
+    # Extract information about the toric base
+    base_rays = matrix(ZZ,rays(base))
+    base_cones = matrix(ZZ, ray_indices(maximal_cones(base)))
+    S1 = cox_ring(base)
+
+    # Construct the rays for the fibre ambient space
+    xray = [0 for i in 1:ncols(base_rays)+2]
+    yray = [0 for i in 1:ncols(base_rays)+2]
+    zray = [0 for i in 1:ncols(base_rays)+2]
+    xray[ncols(base_rays)+1] = 1
+    yray[ncols(base_rays)+2] = 1
+    zray[ncols(base_rays)+1] = -2
+    zray[ncols(base_rays)+2] = -3
+
+    # Construct the rays of the toric ambient space
+    ambient_space_rays = hcat([r for r in base_rays], [-2 for i in 1:nrows(base_rays)], [-3 for i in 1:nrows(base_rays)])
+    ambient_space_rays = vcat(ambient_space_rays, transpose(xray), transpose(yray), transpose(zray))
+
+    # Construct the incidence matrix for the maximal cones of the ambient space
+    ambient_space_max_cones = []
+    for i in 1:nrows(base_cones)
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 1 0])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 0 1])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [0 1 1])])
+    end
+    ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
+
+    # Construct the ambient space and perform consistency check
+    toric_ambient_space = NormalToricVariety(PolyhedralFan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+    set_coordinate_names(toric_ambient_space, vcat(["u$i" for i in 1:nrays(base)], ["x", "y", "z"]))
+    S2 = cox_ring(toric_ambient_space)
+
+    # Compute the Tate sections
+    f = hom(S1, S2, [gens(S2)[i] for i in 1:length(gens(S1))])
+    a1 = sum([rand(Int) * f(b) for b in basis_of_global_sections(anticanonical_bundle(base))])
+    a2 = sum([rand(Int) * f(b) for b in basis_of_global_sections(anticanonical_bundle(base)^2)])
+    a3 = sum([rand(Int) * f(b) for b in basis_of_global_sections(anticanonical_bundle(base)^3)])
+    a4 = sum([rand(Int) * f(b) for b in basis_of_global_sections(anticanonical_bundle(base)^4)])
+    a6 = sum([rand(Int) * f(b) for b in basis_of_global_sections(anticanonical_bundle(base)^6)])
+
+    # Compute the Tate polynomial
+    x = gens(S2)[length(gens(S2))-2]
+    y = gens(S2)[length(gens(S2))-1]
+    z = gens(S2)[length(gens(S2))]
+    pt = x^3 - y^2 + x*y*z*a1 + x^2*z^2*a2 + y*z^3*a3 + x*z^4*a4 + z^6*a6
+
+    # TODO: Compute the toric hypersurface
+    # TODO: Once new Oscar release is available
+    #Y4 = Oscar.ClosedSubvarietyOfToricVariety(toric_ambient_space, [pt])
+
+    # Return the global Tate model
+    return GlobalTateModel(a1, a2, a3, a4, a6, pt, base, toric_ambient_space)
+
+end
+export GenericGlobalTateModel
+
+
+@doc Markdown.doc"""
+    GenericGlobalTateModelOverProjectiveSpace()
+
+This method constructs a global Tate model over the 3-dimensional projective space.
+
+# Examples
+```jldoctest
+julia> using Oscar
+
+julia> GenericGlobalTateModelOverProjectiveSpace()
+A global Tate model
+```
+"""
+GenericGlobalTateModelOverProjectiveSpace() = GenericGlobalTateModel(projective_space(NormalToricVariety,3))
+export GenericGlobalTateModelOverProjectiveSpace
+
+
+@doc Markdown.doc"""
+    SpecificGlobalTateModel(ais::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}, base::Oscar.AbstractNormalToricVariety)
+
+This method operates analogously to `GenericGlobalTateModel(base::Oscar.AbstractNormalToricVariety)`.
+The only difference is that the Tate sections ``a_i`` can be specified with non-generic values.
+
+# Examples
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> a1 = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base))]);
+
+julia> a2 = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base)^2)]);
+
+julia> a3 = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base)^3)]);
+
+julia> a4 = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base)^4)]);
+
+julia> a6 = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base)^6)]);
+
+julia> t = SpecificGlobalTateModel([a1, a2, a3, a4, a6], base)
+A global Tate model
+
+julia> is_smooth(toric_ambient_space(t))
+false
+```
+"""
+function SpecificGlobalTateModel(ais::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}, base::Oscar.AbstractNormalToricVariety)
+
+    # Extract information about the toric base
+    base_rays = matrix(ZZ,rays(base))
+    base_cones = matrix(ZZ, ray_indices(maximal_cones(base)))
+    S1 = cox_ring(base)
+
+    # Consistency checks
+    if dim(base) != 3
+        throw(ArgumentError("We currently focus on global Tate models over 3-dimensional toric base spaces"))
+    end
+    if length(ais) != 5
+        throw(ArgumentError("We require exactly 5 Tate section"))
+    end
+    if any(k -> parent(k) != S1, ais)
+        throw(ArgumentError("All Tate sections must reside in the Cox ring of the base toric variety"))
+    end
+
+    # Construct the rays for the fibre ambient space
+    xray = [0 for i in 1:ncols(base_rays)+2]
+    yray = [0 for i in 1:ncols(base_rays)+2]
+    zray = [0 for i in 1:ncols(base_rays)+2]
+    xray[ncols(base_rays)+1] = 1
+    yray[ncols(base_rays)+2] = 1
+    zray[ncols(base_rays)+1] = -2
+    zray[ncols(base_rays)+2] = -3
+
+    # Construct the rays of the toric ambient space
+    ambient_space_rays = hcat([r for r in base_rays], [-2 for i in 1:nrows(base_rays)], [-3 for i in 1:nrows(base_rays)])
+    ambient_space_rays = vcat(ambient_space_rays, transpose(xray), transpose(yray), transpose(zray))
+
+    # Construct the incidence matrix for the maximal cones of the ambient space
+    ambient_space_max_cones = []
+    for i in 1:nrows(base_cones)
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 1 0])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 0 1])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [0 1 1])])
+    end
+    ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
+
+    # Construct the ambient space and perform consistency check
+    toric_ambient_space = NormalToricVariety(PolyhedralFan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+    set_coordinate_names(toric_ambient_space, vcat(["u$i" for i in 1:nrays(base)], ["x", "y", "z"]))
+    S2 = cox_ring(toric_ambient_space)
+
+    # Compute the Tate polynomial
+    x = gens(S2)[length(gens(S2))-2]
+    y = gens(S2)[length(gens(S2))-1]
+    z = gens(S2)[length(gens(S2))]
+    ring_map = hom(S1, S2, [gens(S2)[i] for i in 1:length(gens(S1))])
+    pt = x^3 - y^2 + x*y*z*ring_map(ais[1]) + x^2*z^2*ring_map(ais[2]) + y*z^3*ring_map(ais[3]) + x*z^4*ring_map(ais[4]) + z^6*ring_map(ais[5])
+
+    # TODO: Compute the toric hypersurface
+    # TODO: Once new Oscar release is available
+    #Y4 = Oscar.ClosedSubvarietyOfToricVariety(toric_ambient_space, [pt])
+
+    # Return the global Tate model
+    return GlobalTateModel(ais[1], ais[2], ais[3], ais[4], ais[5], pt, base, toric_ambient_space)
+
+end
+export SpecificGlobalTateModel
+
+
+#######################################
+# 3: Display
+#######################################
+
+function Base.show(io::IO, cy::GlobalTateModel)
+    join(io, "A global Tate model")
+end

--- a/src/WeierstrassModels/attributes.jl
+++ b/src/WeierstrassModels/attributes.jl
@@ -1,11 +1,29 @@
+#######################################
+# 1: Weierstrass sections
+#######################################
+
 @doc Markdown.doc"""
     poly_f(w::GlobalWeierstrassModel)
 
-Return the polynomial $f$ used for the
+Return the polynomial ``f`` used for the
 construction of the global Weierstrass model.
 
 ```jldoctest
-julia> w = GenericGlobalWeierstrassModelOverProjectiveSpace(3)
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> w = GenericGlobalWeierstrassModel(base)
 A global Weierstrass model
 
 julia> poly_f(w);
@@ -14,43 +32,133 @@ julia> poly_f(w);
 @attr MPolyElem{fmpq} poly_f(w::GlobalWeierstrassModel) = w.poly_f
 export poly_f
 
+
 @doc Markdown.doc"""
     poly_g(w::GlobalWeierstrassModel)
 
-Return the polynomial $g$ used for the
+Return the polynomial ``g`` used for the
 construction of the global Weierstrass model.
 
 ```jldoctest
-julia> w = GenericGlobalWeierstrassModelOverProjectiveSpace(3)
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> w = GenericGlobalWeierstrassModel(base)
 A global Weierstrass model
 
-julia> poly_f(w);
+julia> poly_g(w);
 ```
 """
 @attr MPolyElem{fmpq} poly_g(w::GlobalWeierstrassModel) = w.poly_g
 export poly_g
 
 
+#######################################
+# 2: Weierstrass polynomial
+#######################################
+
+@doc Markdown.doc"""
+    pw(w::GlobalWeierstrassModel)
+
+Return the Weierstrass polynomial of the global Weierstrass model.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> w = GenericGlobalWeierstrassModel(base)
+A global Weierstrass model
+
+julia> pw(w);
+```
+"""
+@attr MPolyElem{fmpq} pw(w::GlobalWeierstrassModel) = w.pw
+export pw
+
+
+#######################################
+# 3: Toric spaces
+#######################################
+
 @doc Markdown.doc"""
     toric_base_space(w::GlobalWeierstrassModel)
 
-If the global Weierstrass model in question was constructed
-over a toric base space, this method returns this toric space.
-Otherwise an error is raised.
+Return the toric base space of the global Weierstrass model.
 
 ```jldoctest
-julia> w = GenericGlobalWeierstrassModelOverProjectiveSpace(3)
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> w = GenericGlobalWeierstrassModel(base)
 A global Weierstrass model
 
-julia> toric_base_space(w)
-A normal, non-affine, smooth, projective, gorenstein, fano, 3-dimensional toric variety without torusfactor
+julia> is_smooth(toric_base_space(w))
+true
 ```
 """
-function toric_base_space(w::GlobalWeierstrassModel)::Oscar.AbstractNormalToricVariety
-    if has_attribute(w, :toric_base_space)
-       return get_attribute(w, :toric_base_space)
-    else
-        throw(ArgumentError("The Weierstrass model in question was not defined over a toric base space"))
-    end
-end
+@attr Oscar.AbstractNormalToricVariety toric_base_space(w::GlobalWeierstrassModel) = w.toric_base_space
+export toric_base_space
+
+
+@doc Markdown.doc"""
+    toric_ambient_space(w::GlobalWeierstrassModel)
+
+Return the toric base space of the global Weierstrass model.
+
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> w = GenericGlobalWeierstrassModel(base)
+A global Weierstrass model
+
+julia> is_smooth(toric_ambient_space(w))
+false
+```
+"""
+@attr Oscar.AbstractNormalToricVariety toric_ambient_space(w::GlobalWeierstrassModel) = w.toric_ambient_space
 export toric_base_space

--- a/src/WeierstrassModels/constructors.jl
+++ b/src/WeierstrassModels/constructors.jl
@@ -44,7 +44,7 @@ toric base space in a manifest way. But even this criterion usually
 allows for many ambient spaces to be used.
 
 To circumvent this obstacle, this method operates in the opposite direction, i.e.
-"bottom-up". That is, it begins by extracting the rays and maximal cones of chose
+"bottom-up". That is, it begins by extracting the rays and maximal cones of the chosen
 toric base space. Subsequently, those rays and cones are extended
 to form one of the many toric ambient spaces. The following example
 demonstrates that the so-obtained ambient space of a (singular) global Weierstrass

--- a/src/WeierstrassModels/constructors.jl
+++ b/src/WeierstrassModels/constructors.jl
@@ -5,12 +5,19 @@
 @attributes mutable struct GlobalWeierstrassModel
     poly_f::MPolyElem{fmpq}
     poly_g::MPolyElem{fmpq}
-    function GlobalWeierstrassModel(poly_f::MPolyElem{fmpq}, poly_g::MPolyElem{fmpq})
-        if parent(poly_f) != parent(poly_g)
-            throw(ArgumentError("The two polynomials f, g must be elements of the same ring, i.e. a ring encoded by the same julia variable"))
-        end
-        ## TODO: Check if there is a base space such that f and g are sections of Kbar^4 and Kbar^6, respectively?
-        return new(poly_f, poly_g)
+    pw::MPolyElem{fmpq}
+    toric_base_space::Oscar.AbstractNormalToricVariety
+    toric_ambient_space::Oscar.AbstractNormalToricVariety
+    # TODO: Once new Oscar release is available
+    #Y4::Oscar.ClosedSubvarietyOfToricVariety
+    function GlobalWeierstrassModel(poly_f::MPolyElem{fmpq},
+                             poly_g::MPolyElem{fmpq},
+                             pw::MPolyElem{fmpq},
+                             toric_base_space::Oscar.AbstractNormalToricVariety,
+                             toric_ambient_space::Oscar.AbstractNormalToricVariety)
+                             # TODO: Once new Oscar release is available
+                             #Y4::Oscar.ClosedSubvarietyOfToricVariety)
+        return new(poly_f, poly_g, pw, toric_base_space, toric_ambient_space)
     end
 end
 export GlobalWeierstrassModel
@@ -21,64 +28,226 @@ export GlobalWeierstrassModel
 #######################################
 
 @doc Markdown.doc"""
-    GlobalWeierstrassModel(polys::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
+    GenericGlobalWeierstrassModel(base::Oscar.AbstractNormalToricVariety)
 
-A global Weierstrass model is a hypersurface cut out by an
-equation of the form $P_w = y^2 - x^3 - f x z^4 - g z^6$.
-Consequently, it is specified by two polynomials $f$ and $g$.
-For convenience, it can be constructed as
-`GlobalWeierstrassModel([f,g])` and via `GlobalWeierstrassModel(f,g)`.
-"""
-function GlobalWeierstrassModel(polys::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}})
-    if length(polys) != 2
-        throw(ArgumentError("Exactly two polynomials f and g must be specified to define a Weierstrass model"))
-    end
-    return GlobalWeierstrassModel(polys[1],polys[2])
-end
-export GlobalWeierstrassModel
+This method constructs a global Weierstrass model over a given toric base
+3-fold. The Weierstrass sections ``f`` and ``g`` are taken with (pseudo)
+random coefficients.
 
+One way to achieve this is to first focus on the Cox ring of the toric
+ambient space. This ring must be graded such that the Weierstrass polynomial
+is homogeneous and cuts out a Calabi-Yau hypersurface. Given this grading,
+one can perform a triangulation. This triangulation will typically
+take a long time to complete and yield a large number of candidate ambient
+spaces. Typically, one wishes to focus on those spaces which contain the
+toric base space in a manifest way. But even this criterion usually
+allows for many ambient spaces to be used.
 
-@doc Markdown.doc"""
-    GenericGlobalWeierstrassModelOverToricSpace(v::Oscar.AbstractNormalToricVariety)
+To circumvent this obstacle, this method operates in the opposite direction, i.e.
+"bottom-up". That is, it begins by extracting the rays and maximal cones of chose
+toric base space. Subsequently, those rays and cones are extended
+to form one of the many toric ambient spaces. The following example
+demonstrates that the so-obtained ambient space of a (singular) global Weierstrass
+model need not be smooth.
 
-Given a toric variety $v$, this method determines
-generic sections $f \in H^0( v, \overline{K}_v^4)$
-and $g \in H^0( v, \overline{K}_v^6)$. Subsequently,
-it constructs the global Weierstrass model defined by
-those two polynomials.
-"""
-function GenericGlobalWeierstrassModelOverToricSpace(v::Oscar.AbstractNormalToricVariety)
-    Kbar = anticanonical_bundle(v)
-    f = sum([rand(Int)*b for b in basis_of_global_sections(Kbar^4)])
-    g = sum([rand(Int)*b for b in basis_of_global_sections(Kbar^6)])
-    w = GlobalWeierstrassModel([f,g])
-    set_attribute!(w, :toric_base_space, v)
-    return w
-end
-export GenericGlobalWeierstrassModelOverToricSpace
-
-
-@doc Markdown.doc"""
-    GenericGlobalWeierstrassModelOverProjectiveSpace(n::Int)
-
-This method constructs the $n$-dimensional projective
-space, determines generic sections $f$ and $g$ of the
-4-th and 6-th power of the anticanonical bundle and then
-constructs the global Weierstrass model defined by
-those two polynomials.
-
+# Examples
 ```jldoctest
-julia> w = GenericGlobalWeierstrassModelOverProjectiveSpace(3)
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> w = GenericGlobalWeierstrassModel(base)
+A global Weierstrass model
+
+julia> is_smooth(toric_ambient_space(w))
+false
+```
+"""
+function GenericGlobalWeierstrassModel(base::Oscar.AbstractNormalToricVariety)
+
+    # Check if the base space is 3-dimensional
+    if dim(base) != 3
+        throw(ArgumentError("We currently focus on global Weierstrass models over 3-dimensional toric base spaces"))
+    end
+
+    # Extract information about the toric base
+    base_rays = matrix(ZZ,rays(base))
+    base_cones = matrix(ZZ, ray_indices(maximal_cones(base)))
+    S1 = cox_ring(base)
+
+    # Construct the rays for the fibre ambient space
+    xray = [0 for i in 1:ncols(base_rays)+2]
+    yray = [0 for i in 1:ncols(base_rays)+2]
+    zray = [0 for i in 1:ncols(base_rays)+2]
+    xray[ncols(base_rays)+1] = 1
+    yray[ncols(base_rays)+2] = 1
+    zray[ncols(base_rays)+1] = -2
+    zray[ncols(base_rays)+2] = -3
+
+    # Construct the rays of the toric ambient space
+    ambient_space_rays = hcat([r for r in base_rays], [-2 for i in 1:nrows(base_rays)], [-3 for i in 1:nrows(base_rays)])
+    ambient_space_rays = vcat(ambient_space_rays, transpose(xray), transpose(yray), transpose(zray))
+
+    # Construct the incidence matrix for the maximal cones of the ambient space
+    ambient_space_max_cones = []
+    for i in 1:nrows(base_cones)
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 1 0])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 0 1])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [0 1 1])])
+    end
+    ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
+
+    # Construct the ambient space and perform consistency check
+    toric_ambient_space = NormalToricVariety(PolyhedralFan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+    set_coordinate_names(toric_ambient_space, vcat(["u$i" for i in 1:nrays(base)], ["x", "y", "z"]))
+    S2 = cox_ring(toric_ambient_space)
+
+    # Compute the Weierstrass sections
+    ring_map = hom(S1, S2, [gens(S2)[i] for i in 1:length(gens(S1))])
+    f = sum([rand(Int) * ring_map(b) for b in basis_of_global_sections(anticanonical_bundle(base)^4)])
+    g = sum([rand(Int) * ring_map(b) for b in basis_of_global_sections(anticanonical_bundle(base)^6)])
+
+    # Compute the Weierstrass polynomial
+    x = gens(S2)[length(gens(S2))-2]
+    y = gens(S2)[length(gens(S2))-1]
+    z = gens(S2)[length(gens(S2))]
+    pw = x^3 - y^2 + f*x*z^4 + g*z^6
+
+    # TODO: Compute the toric hypersurface
+    # TODO: Once new Oscar release is available
+    #Y4 = Oscar.ClosedSubvarietyOfToricVariety(toric_ambient_space, [pt])
+
+    # Return the global Weierstrass model
+    return GlobalWeierstrassModel(f, g, pw, base, toric_ambient_space)
+
+end
+export GenericGlobalWeierstrassModel
+
+
+@doc Markdown.doc"""
+    GenericGlobalWeierstrassModelOverProjectiveSpace()
+
+This method constructs a global Weierstrass model over the 3-dimensional projective space.
+
+# Examples
+```jldoctest
+julia> using Oscar
+
+julia> GenericGlobalWeierstrassModelOverProjectiveSpace()
 A global Weierstrass model
 ```
 """
-function GenericGlobalWeierstrassModelOverProjectiveSpace(n::Int)
-    if n <= 0
-        throw(ArgumentError("The integer specifies the dimension of the projective space and must be at least 1"))
-    end
-    return GenericGlobalWeierstrassModelOverToricSpace(projective_space(NormalToricVariety,n))
-end
+GenericGlobalWeierstrassModelOverProjectiveSpace() = GenericGlobalWeierstrassModel(projective_space(NormalToricVariety,3))
 export GenericGlobalWeierstrassModelOverProjectiveSpace
+
+
+
+@doc Markdown.doc"""
+    SpecificGlobalWeierstrassModel(f::MPolyElem_dec{fmpq, fmpq_mpoly}, g::MPolyElem_dec{fmpq, fmpq_mpoly}, base::Oscar.AbstractNormalToricVariety)
+
+This method operates analogously to `GenericGlobalWeierstrassModel(base::Oscar.AbstractNormalToricVariety)`.
+The only difference is that the Weierstrass sections ``f`` and ``g`` can be specified with non-generic values.
+
+# Examples
+```jldoctest
+julia> using Oscar
+
+julia> test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+A normal toric variety
+
+julia> test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+A normal toric variety
+
+julia> test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+A normal toric variety
+
+julia> base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+A normal toric variety
+
+julia> f = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base)^4)]);
+
+julia> g = sum([rand(Int) * b for b in basis_of_global_sections(anticanonical_bundle(base)^6)]);
+
+julia> w = SpecificGlobalWeierstrassModel(f, g, base)
+A global Weierstrass model
+
+julia> is_smooth(toric_ambient_space(w))
+false
+```
+"""
+function SpecificGlobalWeierstrassModel(f::MPolyElem_dec{fmpq, fmpq_mpoly}, g::MPolyElem_dec{fmpq, fmpq_mpoly}, base::Oscar.AbstractNormalToricVariety)
+
+    # Extract information about the toric base
+    base_rays = matrix(ZZ,rays(base))
+    base_cones = matrix(ZZ, ray_indices(maximal_cones(base)))
+    S1 = cox_ring(base)
+
+    # Consistency checks
+    if dim(base) != 3
+        throw(ArgumentError("We currently focus on global Weierstrass models over 3-dimensional toric base spaces"))
+    end
+    if parent(f) != S1
+        throw(ArgumentError("All Weierstrass sections must reside in the Cox ring of the base toric variety"))
+    end
+    if parent(g) != S1
+        throw(ArgumentError("All Weierstrass sections must reside in the Cox ring of the base toric variety"))
+    end
+
+    # Construct the rays for the fibre ambient space
+    xray = [0 for i in 1:ncols(base_rays)+2]
+    yray = [0 for i in 1:ncols(base_rays)+2]
+    zray = [0 for i in 1:ncols(base_rays)+2]
+    xray[ncols(base_rays)+1] = 1
+    yray[ncols(base_rays)+2] = 1
+    zray[ncols(base_rays)+1] = -2
+    zray[ncols(base_rays)+2] = -3
+
+    # Construct the rays of the toric ambient space
+    ambient_space_rays = hcat([r for r in base_rays], [-2 for i in 1:nrows(base_rays)], [-3 for i in 1:nrows(base_rays)])
+    ambient_space_rays = vcat(ambient_space_rays, transpose(xray), transpose(yray), transpose(zray))
+
+    # Construct the incidence matrix for the maximal cones of the ambient space
+    ambient_space_max_cones = []
+    for i in 1:nrows(base_cones)
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 1 0])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 0 1])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [0 1 1])])
+    end
+    ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
+
+    # Construct the ambient space and perform consistency check
+    toric_ambient_space = NormalToricVariety(PolyhedralFan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+    set_coordinate_names(toric_ambient_space, vcat(["u$i" for i in 1:nrays(base)], ["x", "y", "z"]))
+    S2 = cox_ring(toric_ambient_space)
+
+    # Compute the Weierstrass sections
+    ring_map = hom(S1, S2, [gens(S2)[i] for i in 1:length(gens(S1))])
+
+    # Compute the Weierstrass polynomial
+    x = gens(S2)[length(gens(S2))-2]
+    y = gens(S2)[length(gens(S2))-1]
+    z = gens(S2)[length(gens(S2))]
+    pw = x^3 - y^2 + ring_map(f)*x*z^4 + ring_map(g)*z^6
+
+    # TODO: Compute the toric hypersurface
+    # TODO: Once new Oscar release is available
+    #Y4 = Oscar.ClosedSubvarietyOfToricVariety(toric_ambient_space, [pt])
+
+    # Return the global Weierstrass model
+    return GlobalWeierstrassModel(f, g, pw, base, toric_ambient_space)
+
+end
+export SpecificGlobalWeierstrassModel
 
 
 #######################################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,39 +4,7 @@ using Oscar
 
 
 #############################################################
-# 1: Construction and properties of global Weierstrass models
-#############################################################
-
-w = GenericGlobalWeierstrassModelOverProjectiveSpace(3)
-Base.show(w)
-
-@testset "Test properties of Weierstrass models" begin
-    @test parent(poly_f(w)) == cox_ring(toric_base_space(w))
-    @test parent(poly_g(w)) == cox_ring(toric_base_space(w))
-end
-
-
-#############################################################
-# 2: Test if errors are raised where we want them
-#############################################################
-
-P3 = projective_space(NormalToricVariety,3)
-f = sum([rand(Int)*b for b in basis_of_global_sections(anticanonical_bundle(P3)^4)]);
-g = sum([rand(Int)*b for b in basis_of_global_sections(anticanonical_bundle(P3)^6)]);
-F2 = hirzebruch_surface(2)
-g2 = sum([rand(Int)*b for b in basis_of_global_sections(anticanonical_bundle(F2)^6)]);
-
-@testset "Test errors to be raised in Weierstrass models" begin
-    @test_throws ArgumentError GenericGlobalWeierstrassModelOverProjectiveSpace(-1)
-    @test_throws ArgumentError GenericGlobalWeierstrassModelOverProjectiveSpace(0)
-    @test_throws ArgumentError toric_base_space(GlobalWeierstrassModel([f,g]))
-    @test_throws ArgumentError GlobalWeierstrassModel([f,g2])
-    @test_throws ArgumentError GlobalWeierstrassModel([f,g,g2])
-end
-
-
-#############################################################
-# 3: Construction and properties of global Tate models
+# 1: Compute fibrations
 #############################################################
 
 test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
@@ -45,8 +13,32 @@ test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
 base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
 t = GenericGlobalTateModel(base)
 Base.show(t)
+w = GenericGlobalWeierstrassModel(base)
+Base.show(w)
 
-@testset "Test properties of global Tate models" begin
+#############################################################
+# 1: Test global Weierstrass models
+#############################################################
+
+@testset "Attributes of global Weierstrass models" begin
+    @test parent(poly_f(w)) == cox_ring(toric_ambient_space(w))
+    @test parent(poly_g(w)) == cox_ring(toric_ambient_space(w))
+    @test parent(pw(w)) == cox_ring(toric_ambient_space(w))
+    @test dim(toric_base_space(w)) == 3
+    @test dim(toric_ambient_space(w)) == 5
+    @test is_smooth(toric_ambient_space(w)) == false
+end
+
+@testset "Error messages in global Weierstrass models" begin
+    @test_throws ArgumentError GenericGlobalWeierstrassModel(hirzebruch_surface(1))
+end
+
+
+#############################################################
+# 2: Test global Tate models
+#############################################################
+
+@testset "Attributes of global Tate models" begin
     @test parent(a1(t)) == cox_ring(toric_ambient_space(t))
     @test parent(a2(t)) == cox_ring(toric_ambient_space(t))
     @test parent(a3(t)) == cox_ring(toric_ambient_space(t))
@@ -58,6 +50,6 @@ Base.show(t)
     @test is_smooth(toric_ambient_space(t)) == false
 end
 
-@testset "Test errors to be raised in Tate models" begin
+@testset "Error messages in global Weierstrass models" begin
     @test_throws ArgumentError GenericGlobalTateModel(hirzebruch_surface(1))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using FTheoryTools
 using Test
 using Oscar
 
+
 #############################################################
 # 1: Construction and properties of global Weierstrass models
 #############################################################
@@ -31,4 +32,32 @@ g2 = sum([rand(Int)*b for b in basis_of_global_sections(anticanonical_bundle(F2)
     @test_throws ArgumentError toric_base_space(GlobalWeierstrassModel([f,g]))
     @test_throws ArgumentError GlobalWeierstrassModel([f,g2])
     @test_throws ArgumentError GlobalWeierstrassModel([f,g,g2])
+end
+
+
+#############################################################
+# 3: Construction and properties of global Tate models
+#############################################################
+
+test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
+test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
+test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
+base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
+t = GenericGlobalTateModel(base)
+Base.show(t)
+
+@testset "Test properties of global Tate models" begin
+    @test parent(a1(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(a2(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(a3(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(a4(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(a6(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(pt(t)) == cox_ring(toric_ambient_space(t))
+    @test dim(toric_base_space(t)) == 3
+    @test dim(toric_ambient_space(t)) == 5
+    @test is_smooth(toric_ambient_space(t)) == false
+end
+
+@testset "Test errors to be raised in Tate models" begin
+    @test_throws ArgumentError GenericGlobalTateModel(hirzebruch_surface(1))
 end


### PR DESCRIPTION
- Implements functionality for Tate models over concrete toric spaces.
- Code not complete/fully optimized yet (and the tests probably do not pass yet). To be updated later.

Related: Weierstrass models should be updated/adjusted to a similar state once complete.

(cc @apturner)