### PR TITLE
Functionality for fibrations over generic/unspecified base spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ We base this project on [OSCAR](https://oscar.computeralgebra.de/) for general f
 4. Finally, register and build `FTheoryTools.jl` as follows:
 ```julia
     using Pkg
+    Pkg.add("Oscar")
     Pkg.develop(path="path/to/your/FTheoryTools.jl")
     Pkg.build("FTheoryTools")
 ```
@@ -64,7 +65,7 @@ We base this project on [OSCAR](https://oscar.computeralgebra.de/) for general f
 
 ## Documentation
 
-For detailed information about the implemented functionality, please take a look at the most recent [documentation](https://herearound.github.io/FTheoryTools.jl/dev/).
+For detailed information about the implemented functionality, please take a look at the most recent [documentation](https://julia-meets-string-theory.github.io/FTheoryTools.jl/dev/).
 
 
 ## Bugs and feature requests

--- a/docs/doc.main
+++ b/docs/doc.main
@@ -4,6 +4,7 @@
    "FtheoryTools" => [
       "FTheoryTools/Introduction.md"
       "FTheoryTools/Weierstrass.md"
+      "FTheoryTools/WeierstrassGeneralBase.md"
       "FTheoryTools/Tate.md"
       "FTheoryTools/TateGeneralBase.md"
    ],

--- a/docs/doc.main
+++ b/docs/doc.main
@@ -5,5 +5,6 @@
       "FTheoryTools/Introduction.md"
       "FTheoryTools/Weierstrass.md"
       "FTheoryTools/Tate.md"
+      "FTheoryTools/TateGeneralBase.md"
    ],
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,9 @@ makedocs(
     pages = ["index.md",
             "FTheoryTools/Introduction.md",
             "Tools" => ["FTheoryTools/Weierstrass.md"],
+            "Tools" => ["FTheoryTools/WeierstrassGeneralBase.md"],
             "Tools" => ["FTheoryTools/Tate.md"],
+            "Tools" => ["FTheoryTools/TateGeneralBase.md"],
             ]
     )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,10 +12,10 @@ makedocs(
     doctest = false,
     pages = ["index.md",
             "FTheoryTools/Introduction.md",
-            "Tools" => ["FTheoryTools/Weierstrass.md"],
-            "Tools" => ["FTheoryTools/WeierstrassGeneralBase.md"],
-            "Tools" => ["FTheoryTools/Tate.md"],
-            "Tools" => ["FTheoryTools/TateGeneralBase.md"],
+            "Weierstrass models" => ["FTheoryTools/Weierstrass.md",
+                                     "FTheoryTools/WeierstrassGeneralBase.md"],
+            "Tate models" => ["FTheoryTools/Tate.md",
+                              "FTheoryTools/TateGeneralBase.md"],
             ]
     )
 

--- a/docs/src/FTheoryTools/Introduction.md
+++ b/docs/src/FTheoryTools/Introduction.md
@@ -58,6 +58,7 @@ We base this project on [OSCAR](https://oscar.computeralgebra.de/) for general f
 4. Finally, register and build `FTheoryTools.jl` as follows:
 ```julia
     using Pkg
+    Pkg.add("Oscar")
     Pkg.develop(path="path/to/your/FTheoryTools.jl")
     Pkg.build("FTheoryTools")
 ```
@@ -65,7 +66,7 @@ We base this project on [OSCAR](https://oscar.computeralgebra.de/) for general f
 
 ## Documentation
 
-For detailed information about the implemented functionality, please take a look at the most recent [documentation](https://herearound.github.io/FTheoryTools.jl/dev/).
+For detailed information about the implemented functionality, please take a look at the most recent [documentation](https://julia-meets-string-theory.github.io/FTheoryTools.jl/dev/).
 
 
 ## Bugs and feature requests

--- a/docs/src/FTheoryTools/Tate.md
+++ b/docs/src/FTheoryTools/Tate.md
@@ -39,12 +39,12 @@ SpecificGlobalTateModel(ais::Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}, base::Osca
 ## Attributes
 
 ```@docs
-a1(t::GlobalTateModel)
-a2(t::GlobalTateModel)
-a3(t::GlobalTateModel)
-a4(t::GlobalTateModel)
-a6(t::GlobalTateModel)
-pt(t::GlobalTateModel)
+tate_section_a1(t::GlobalTateModel)
+tate_section_a2(t::GlobalTateModel)
+tate_section_a3(t::GlobalTateModel)
+tate_section_a4(t::GlobalTateModel)
+tate_section_a6(t::GlobalTateModel)
+tate_polynomial(t::GlobalTateModel)
 toric_base_space(t::GlobalTateModel)
 toric_ambient_space(t::GlobalTateModel)
 ```

--- a/docs/src/FTheoryTools/TateGeneralBase.md
+++ b/docs/src/FTheoryTools/TateGeneralBase.md
@@ -1,0 +1,57 @@
+```@meta
+CurrentModule = FTheoryTools
+```
+
+```@contents
+Pages = ["Tate.md"]
+```
+
+# Global Tate models without specified base space
+
+This method constructs a global Tate model over a base space that is not
+fully specified. Rather, it assums that a base space exists such that
+the Tate sections ``a_i`` are well-defined so that the Tate model in
+question is well-defined.
+
+For many practical applications, one wishes to assume a further factorization
+of the Tate sections ``a_i``. This has the advantage that one can engineer
+singularity loci or even the singularity type over a specific locus. This is
+the backbone of many F-theory constructions.
+
+To this end, this method accepts a polynomial ring whose variables are the sections
+used in the desired factorization of the Tate sections ``a_i``. For example, if we
+desired a factorization:
+- ``a_1 = a_{10} w^0``,
+- ``a_2 = a_{21} w^1``,
+- ``a_3 = a_{32} w^2``,
+- ``a_4 = a_{43} w^3``,
+- ``a_6 = a_{65} w^5``,
+then the polynomial ring in question is the ring with indeterminates
+``a_{10}``, ``a_{21}``, ``a_{32}``, ``a_{43}``, ``a_{65}`` and ``w``.
+
+In theory, one can consider these indeterminates as local coordinate of the base space.
+For the computer implementation, this ring will therefore serve as the coordinate
+ring of an auxiliary toric base space, namely an affine space with those coordinates.
+
+For such geometries, we support the following functionality.
+
+
+## Constructors
+
+```@docs
+GlobalTateModel(ais::Vector{fmpq_mpoly}, auxiliary_base_ring::MPolyRing)
+```
+
+
+## Attributes
+
+```@docs
+tate_section_a1(t::TateModelOverGeneralBaseSpace)
+tate_section_a2(t::TateModelOverGeneralBaseSpace)
+tate_section_a3(t::TateModelOverGeneralBaseSpace)
+tate_section_a4(t::TateModelOverGeneralBaseSpace)
+tate_section_a6(t::TateModelOverGeneralBaseSpace)
+tate_polynomial(t::TateModelOverGeneralBaseSpace)
+auxiliary_base_space(t::TateModelOverGeneralBaseSpace)
+auxiliary_ambient_space(t::TateModelOverGeneralBaseSpace)
+```

--- a/docs/src/FTheoryTools/Weierstrass.md
+++ b/docs/src/FTheoryTools/Weierstrass.md
@@ -34,9 +34,9 @@ SpecificGlobalWeierstrassModel(f::MPolyElem_dec{fmpq, fmpq_mpoly}, g::MPolyElem_
 ## Attributes
 
 ```@docs
-poly_f(w::GlobalWeierstrassModel)
-poly_g(w::GlobalWeierstrassModel)
-pw(w::GlobalWeierstrassModel)
+weierstrass_section_f(w::GlobalWeierstrassModel)
+weierstrass_section_g(w::GlobalWeierstrassModel)
+weierstrass_polynomial(w::GlobalWeierstrassModel)
 toric_base_space(w::GlobalWeierstrassModel)
 toric_ambient_space(w::GlobalWeierstrassModel)
 ```

--- a/docs/src/FTheoryTools/WeierstrassGeneralBase.md
+++ b/docs/src/FTheoryTools/WeierstrassGeneralBase.md
@@ -1,0 +1,47 @@
+```@meta
+CurrentModule = FTheoryTools
+```
+
+```@contents
+Pages = ["Weierstrass.md"]
+```
+
+# Global Weierstrass models
+
+This method constructs a global Weierstrass model over a base space that is not
+fully specified. Rather, it assums that a base space exists such that
+the Weierstrass sections ``f`` and ``g`` are well-defined, so that the
+Weierstrass model in question is well-defined.
+
+For many practical applications, one wishes to assume a further specialize
+the Weierstrass sections ``f`` and ``g``. This has the advantage that one can
+engineer singularity loci or even the singularity type over a specific locus.
+To some extend, this is the backbone of many F-theory constructions.
+
+Consequently, the construction of such models accepts a polynomial ring whose
+variables are the sections used in the desired factorization of the Weierstrass
+sections ``f`` and ``g``.
+
+In theory, one can consider the indeterminates of this auxiliary ring as a
+(possilby redundant) set of local coordinate of the base space. For the computer
+implementation, this ring will therefore serve as the coordinate ring of an auxiliary
+toric base space, namely an affine space with those coordinates.
+
+For such geometries, we support the following functionality.
+
+## Constructors
+
+We support the following constructors:
+```@docs
+GlobalWeierstrassModel(f::fmpq_mpoly, g::fmpq_mpoly, auxiliary_base_ring::MPolyRing)
+```
+
+## Attributes
+
+```@docs
+weierstrass_section_f(w::WeierstrassModelOverGeneralBaseSpace)
+weierstrass_section_g(w::WeierstrassModelOverGeneralBaseSpace)
+weierstrass_polynomial(w::WeierstrassModelOverGeneralBaseSpace)
+auxiliary_base_space(w::WeierstrassModelOverGeneralBaseSpace)
+auxiliary_ambient_space(w::WeierstrassModelOverGeneralBaseSpace)
+```

--- a/src/FTheoryTools.jl
+++ b/src/FTheoryTools.jl
@@ -31,8 +31,10 @@ const version = IS_DEV ? VersionNumber("$(VERSION_NUMBER)-dev") : VERSION_NUMBER
 include("WeierstrassModels/constructors.jl")
 include("WeierstrassModels/attributes.jl")
 
-# include files
 include("TateModels/constructors.jl")
 include("TateModels/attributes.jl")
+
+include("TateModelsOverGeneralBaseSpace/constructors.jl")
+include("TateModelsOverGeneralBaseSpace/attributes.jl")
 
 end

--- a/src/FTheoryTools.jl
+++ b/src/FTheoryTools.jl
@@ -31,6 +31,9 @@ const version = IS_DEV ? VersionNumber("$(VERSION_NUMBER)-dev") : VERSION_NUMBER
 include("WeierstrassModels/constructors.jl")
 include("WeierstrassModels/attributes.jl")
 
+include("WeierstrassModelsOverGeneralBaseSpace/constructors.jl")
+include("WeierstrassModelsOverGeneralBaseSpace/attributes.jl")
+
 include("TateModels/constructors.jl")
 include("TateModels/attributes.jl")
 

--- a/src/TateModels/attributes.jl
+++ b/src/TateModels/attributes.jl
@@ -3,7 +3,7 @@
 #######################################
 
 @doc Markdown.doc"""
-    a1(t::GlobalTateModel)
+    tate_section_a1(t::GlobalTateModel)
 
 Return the Tate section ``a_1``.
 
@@ -25,15 +25,15 @@ A normal toric variety
 julia> t = GenericGlobalTateModel(base)
 A global Tate model
 
-julia> a1(t);
+julia> tate_section_a1(t);
 ```
 """
-@attr MPolyElem{fmpq} a1(t::GlobalTateModel) = t.a1
-export a1
+@attr MPolyElem{fmpq} tate_section_a1(t::GlobalTateModel) = t.a1
+export tate_section_a1
 
 
 @doc Markdown.doc"""
-    a2(t::GlobalTateModel)
+    tate_section_a2(t::GlobalTateModel)
 
 Return the Tate section ``a_2``.
 
@@ -55,15 +55,15 @@ A normal toric variety
 julia> t = GenericGlobalTateModel(base)
 A global Tate model
 
-julia> a2(t);
+julia> tate_section_a2(t);
 ```
 """
-@attr MPolyElem{fmpq} a2(t::GlobalTateModel) = t.a2
-export a2
+@attr MPolyElem{fmpq} tate_section_a2(t::GlobalTateModel) = t.a2
+export tate_section_a2
 
 
 @doc Markdown.doc"""
-    a3(t::GlobalTateModel)
+    tate_section_a3(t::GlobalTateModel)
 
 Return the Tate section ``a_3``.
 
@@ -85,15 +85,15 @@ A normal toric variety
 julia> t = GenericGlobalTateModel(base)
 A global Tate model
 
-julia> a3(t);
+julia> tate_section_a3(t);
 ```
 """
-@attr MPolyElem{fmpq} a3(t::GlobalTateModel) = t.a3
-export a3
+@attr MPolyElem{fmpq} tate_section_a3(t::GlobalTateModel) = t.a3
+export tate_section_a3
 
 
 @doc Markdown.doc"""
-    a4(t::GlobalTateModel)
+    tate_section_a4(t::GlobalTateModel)
 
 Return the Tate section ``a_4``.
 
@@ -115,15 +115,15 @@ A normal toric variety
 julia> t = GenericGlobalTateModel(base)
 A global Tate model
 
-julia> a4(t);
+julia> tate_section_a4(t);
 ```
 """
-@attr MPolyElem{fmpq} a4(t::GlobalTateModel) = t.a4
-export a4
+@attr MPolyElem{fmpq} tate_section_a4(t::GlobalTateModel) = t.a4
+export tate_section_a4
 
 
 @doc Markdown.doc"""
-    a6(t::GlobalTateModel)
+    tate_section_a6(t::GlobalTateModel)
 
 Return the Tate section ``a_6``.
 
@@ -145,11 +145,11 @@ A normal toric variety
 julia> t = GenericGlobalTateModel(base)
 A global Tate model
 
-julia> a6(t);
+julia> tate_section_a6(t);
 ```
 """
-@attr MPolyElem{fmpq} a6(t::GlobalTateModel) = t.a6
-export a6
+@attr MPolyElem{fmpq} tate_section_a6(t::GlobalTateModel) = t.a6
+export tate_section_a6
 
 
 #######################################
@@ -157,7 +157,7 @@ export a6
 #######################################
 
 @doc Markdown.doc"""
-    pt(t::GlobalTateModel)
+    tate_polynomial(t::GlobalTateModel)
 
 Return the Tate polynomial of the global Tate model.
 
@@ -179,11 +179,11 @@ A normal toric variety
 julia> t = GenericGlobalTateModel(base)
 A global Tate model
 
-julia> pt(t);
+julia> tate_polynomial(t);
 ```
 """
-@attr MPolyElem{fmpq} pt(t::GlobalTateModel) = t.pt
-export pt
+@attr MPolyElem{fmpq} tate_polynomial(t::GlobalTateModel) = t.pt
+export tate_polynomial
 
 
 #######################################

--- a/src/TateModelsOverGeneralBaseSpace/attributes.jl
+++ b/src/TateModelsOverGeneralBaseSpace/attributes.jl
@@ -1,0 +1,277 @@
+#######################################
+# 1: The Tate sections
+#######################################
+
+@doc Markdown.doc"""
+    tate_section_a1(t::TateModelOverGeneralBaseSpace)
+
+Return the Tate section ``a_1``.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> tate_section_a1(t)
+a10
+```
+"""
+@attr MPolyElem{fmpq} tate_section_a1(t::TateModelOverGeneralBaseSpace) = t.a1
+export tate_section_a1
+
+
+@doc Markdown.doc"""
+    tate_section_a2(t::TateModelOverGeneralBaseSpace)
+
+Return the Tate section ``a_2``.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> tate_section_a2(t)
+a21*w
+```
+"""
+@attr MPolyElem{fmpq} tate_section_a2(t::TateModelOverGeneralBaseSpace) = t.a2
+export tate_section_a2
+
+
+@doc Markdown.doc"""
+    tate_section_a3(t::TateModelOverGeneralBaseSpace)
+
+Return the Tate section ``a_3``.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> tate_section_a3(t)
+a32*w^2
+```
+"""
+@attr MPolyElem{fmpq} tate_section_a3(t::TateModelOverGeneralBaseSpace) = t.a3
+export tate_section_a3
+
+
+@doc Markdown.doc"""
+    a4(t::TateModelOverGeneralBaseSpace)
+
+Return the Tate section ``a_4``.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> tate_section_a4(t)
+a43*w^3
+```
+"""
+@attr MPolyElem{fmpq} tate_section_a4(t::TateModelOverGeneralBaseSpace) = t.a4
+export tate_section_a4
+
+
+@doc Markdown.doc"""
+    tate_section_a6(t::TateModelOverGeneralBaseSpace)
+
+Return the Tate section ``a_6``.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> tate_section_a6(t)
+a65*w^5
+```
+"""
+@attr MPolyElem{fmpq} tate_section_a6(t::TateModelOverGeneralBaseSpace) = t.a6
+export tate_section_a6
+
+
+#######################################
+# 2: The Tate polynomial
+#######################################
+
+@doc Markdown.doc"""
+    tate_polynomial(t::TateModelOverGeneralBaseSpace)
+
+Return the Tate polynomial of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> tate_polynomial(t)
+a10*x*y*z + a21*w*x^2*z^2 + a32*w^2*y*z^3 + a43*w^3*x*z^4 + a65*w^5*z^6 + x^3 - y^2
+```
+"""
+@attr MPolyElem{fmpq} tate_polynomial(t::TateModelOverGeneralBaseSpace) = t.pt
+export tate_polynomial
+
+
+#######################################
+# 3: Auxiliary toric spaces
+#######################################
+
+@doc Markdown.doc"""
+    auxiliary_base_space(t::TateModelOverGeneralBaseSpace)
+
+Return the toric base space of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> auxiliary_base_space(t)
+A normal, affine, 6-dimensional toric variety
+```
+"""
+@attr Oscar.AbstractNormalToricVariety auxiliary_base_space(t::TateModelOverGeneralBaseSpace) = t.auxiliary_base_space
+export auxiliary_base_space
+
+
+@doc Markdown.doc"""
+    auxiliary_ambient_space(t::TateModelOverGeneralBaseSpace)
+
+Return the toric ambient space of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> auxiliary_ambient_space(t)
+A normal toric variety
+
+julia> dim(auxiliary_ambient_space(t))
+8
+```
+"""
+@attr Oscar.AbstractNormalToricVariety auxiliary_ambient_space(t::TateModelOverGeneralBaseSpace) = t.auxiliary_ambient_space
+export auxiliary_ambient_space

--- a/src/TateModelsOverGeneralBaseSpace/constructors.jl
+++ b/src/TateModelsOverGeneralBaseSpace/constructors.jl
@@ -1,0 +1,145 @@
+######################################################
+# 1: The Julia type for TateModelOverGeneralBaseSpace
+######################################################
+
+@attributes mutable struct TateModelOverGeneralBaseSpace
+    a1::MPolyElem_dec{fmpq, fmpq_mpoly}
+    a2::MPolyElem_dec{fmpq, fmpq_mpoly}
+    a3::MPolyElem_dec{fmpq, fmpq_mpoly}
+    a4::MPolyElem_dec{fmpq, fmpq_mpoly}
+    a6::MPolyElem_dec{fmpq, fmpq_mpoly}
+    pt::MPolyElem_dec{fmpq, fmpq_mpoly}
+    auxiliary_base_space::Oscar.AbstractNormalToricVariety
+    auxiliary_ambient_space::Oscar.AbstractNormalToricVariety
+    # TODO: Once new Oscar release is available
+    #Y4::Oscar.ClosedSubvarietyOfToricVariety
+    function TateModelOverGeneralBaseSpace(a1::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                            a2::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                            a3::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                            a4::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                            a6::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                            pt::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                            auxiliary_base_space::Oscar.AbstractNormalToricVariety,
+                                            auxiliary_ambient_space::Oscar.AbstractNormalToricVariety)
+                                            # TODO: Once new Oscar release is available
+                                            #Y4::Oscar.ClosedSubvarietyOfToricVariety)
+        return new(a1, a2, a3, a4, a6, pt, auxiliary_base_space, auxiliary_ambient_space)
+    end
+end
+export TateModelOverGeneralBaseSpace
+
+
+#######################################
+# 2: Generic constructor
+#######################################
+
+@doc Markdown.doc"""
+    GlobalTateModel(ais::Vector{fmpq_mpoly}, auxiliary_base_ring::MPolyRing)
+
+This method constructs a global Tate model over a base space that is not
+fully specified. The following example exemplifies this approach.
+
+# Examples
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"];
+
+julia> a1 = a10;
+
+julia> a2 = a21 * w;
+
+julia> a3 = a32 * w^2;
+
+julia> a4 = a43 * w^3;
+
+julia> a6 = a65 * w^5;
+
+julia> ais = [a1, a2, a3, a4, a6];
+
+julia> t = GlobalTateModel(ais, auxiliary_base_ring)
+A global Tate model over a general base space
+
+julia> tate_polynomial(t)
+a10*x*y*z + a21*w*x^2*z^2 + a32*w^2*y*z^3 + a43*w^3*x*z^4 + a65*w^5*z^6 + x^3 - y^2
+
+julia> auxiliary_base_space(t)
+A normal, affine, 6-dimensional toric variety
+
+julia> auxiliary_ambient_space(t)
+A normal toric variety
+
+julia> dim(auxiliary_ambient_space(t))
+8
+```
+"""
+function GlobalTateModel(ais::Vector{fmpq_mpoly}, auxiliary_base_ring::MPolyRing)
+
+    # Check if the base space is 3-dimensional
+    if length(ais) != 5
+        throw(ArgumentError("We expect exactly 5 Tate sections"))
+    end
+    if any(k -> parent(k) != auxiliary_base_ring, ais)
+        throw(ArgumentError("All Tate sections must reside in the provided auxiliary base ring"))
+    end
+
+    # Construct auxiliary base space
+    auxiliary_base_space = affine_space(NormalToricVariety, length(gens(auxiliary_base_ring)))
+    set_coordinate_names(auxiliary_base_space, [string(k) for k in gens(auxiliary_base_ring)])
+
+    # Extract information about the auxiliary toric base space
+    base_rays = matrix(ZZ,rays(auxiliary_base_space))
+    base_cones = matrix(ZZ, ray_indices(maximal_cones(auxiliary_base_space)))
+
+    # Construct the rays for the fibre ambient space
+    xray = [0 for i in 1:ncols(base_rays)+2]
+    yray = [0 for i in 1:ncols(base_rays)+2]
+    zray = [0 for i in 1:ncols(base_rays)+2]
+    xray[ncols(base_rays)+1] = 1
+    yray[ncols(base_rays)+2] = 1
+    zray[ncols(base_rays)+1] = -2
+    zray[ncols(base_rays)+2] = -3
+
+    # Construct the rays of the auxiliary toric ambient space
+    ambient_space_rays = hcat([r for r in base_rays], [-2 for i in 1:nrows(base_rays)], [-3 for i in 1:nrows(base_rays)])
+    ambient_space_rays = vcat(ambient_space_rays, transpose(xray), transpose(yray), transpose(zray))
+
+    # Construct the incidence matrix for the maximal cones of the ambient space
+    ambient_space_max_cones = []
+    for i in 1:nrows(base_cones)
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 1 0])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 0 1])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [0 1 1])])
+    end
+    ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
+
+    # Construct the ambient space and perform consistency check
+    auxiliary_ambient_space = NormalToricVariety(PolyhedralFan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+    set_coordinate_names(auxiliary_ambient_space, vcat([string(k) for k in gens(auxiliary_base_ring)], ["x", "y", "z"]))
+    S2 = cox_ring(auxiliary_ambient_space)
+
+    # Compute the Tate polynomial
+    f = hom(auxiliary_base_ring, S2, [gens(S2)[i] for i in 1:length(gens(auxiliary_base_ring))])
+    x = gens(S2)[length(gens(S2))-2]
+    y = gens(S2)[length(gens(S2))-1]
+    z = gens(S2)[length(gens(S2))]
+    pt = x^3 - y^2 + x*y*z*f(ais[1]) + x^2*z^2*f(ais[2]) + y*z^3*f(ais[3]) + x*z^4*f(ais[4]) + z^6*f(ais[5])
+
+    # TODO: Compute the toric hypersurface
+    # TODO: Once new Oscar release is available
+    #Y4 = Oscar.ClosedSubvarietyOfToricVariety(auxiliary_ambient_space, [pt])
+
+    # Return the global Tate model
+    return TateModelOverGeneralBaseSpace(f(ais[1]), f(ais[2]), f(ais[3]), f(ais[4]), f(ais[5]), pt, auxiliary_base_space, auxiliary_ambient_space)
+
+end
+export GlobalTateModel
+
+
+#######################################
+# 3: Display
+#######################################
+
+function Base.show(io::IO, cy::TateModelOverGeneralBaseSpace)
+    join(io, "A global Tate model over a general base space")
+end

--- a/src/WeierstrassModels/attributes.jl
+++ b/src/WeierstrassModels/attributes.jl
@@ -3,7 +3,7 @@
 #######################################
 
 @doc Markdown.doc"""
-    poly_f(w::GlobalWeierstrassModel)
+    weierstrass_section_f(w::GlobalWeierstrassModel)
 
 Return the polynomial ``f`` used for the
 construction of the global Weierstrass model.
@@ -26,15 +26,15 @@ A normal toric variety
 julia> w = GenericGlobalWeierstrassModel(base)
 A global Weierstrass model
 
-julia> poly_f(w);
+julia> weierstrass_section_f(w);
 ```
 """
-@attr MPolyElem{fmpq} poly_f(w::GlobalWeierstrassModel) = w.poly_f
-export poly_f
+@attr MPolyElem{fmpq} weierstrass_section_f(w::GlobalWeierstrassModel) = w.poly_f
+export weierstrass_section_f
 
 
 @doc Markdown.doc"""
-    poly_g(w::GlobalWeierstrassModel)
+    weierstrass_section_g(w::GlobalWeierstrassModel)
 
 Return the polynomial ``g`` used for the
 construction of the global Weierstrass model.
@@ -57,11 +57,11 @@ A normal toric variety
 julia> w = GenericGlobalWeierstrassModel(base)
 A global Weierstrass model
 
-julia> poly_g(w);
+julia> weierstrass_section_g(w);
 ```
 """
-@attr MPolyElem{fmpq} poly_g(w::GlobalWeierstrassModel) = w.poly_g
-export poly_g
+@attr MPolyElem{fmpq} weierstrass_section_g(w::GlobalWeierstrassModel) = w.poly_g
+export weierstrass_section_g
 
 
 #######################################
@@ -69,7 +69,7 @@ export poly_g
 #######################################
 
 @doc Markdown.doc"""
-    pw(w::GlobalWeierstrassModel)
+    weierstrass_polynomial(w::GlobalWeierstrassModel)
 
 Return the Weierstrass polynomial of the global Weierstrass model.
 
@@ -91,11 +91,11 @@ A normal toric variety
 julia> w = GenericGlobalWeierstrassModel(base)
 A global Weierstrass model
 
-julia> pw(w);
+julia> weierstrass_polynomial(w);
 ```
 """
-@attr MPolyElem{fmpq} pw(w::GlobalWeierstrassModel) = w.pw
-export pw
+@attr MPolyElem{fmpq} weierstrass_polynomial(w::GlobalWeierstrassModel) = w.pw
+export weierstrass_polynomial
 
 
 #######################################

--- a/src/WeierstrassModelsOverGeneralBaseSpace/attributes.jl
+++ b/src/WeierstrassModelsOverGeneralBaseSpace/attributes.jl
@@ -1,0 +1,115 @@
+#######################################
+# 1: The Tate sections
+#######################################
+
+@doc Markdown.doc"""
+    weierstrass_section_f(w::WeierstrassModelOverGeneralBaseSpace)
+
+Return the Weierstrass section ``f``.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (f, g) = QQ["f", "g"];
+
+julia> w = GlobalWeierstrassModel(f, g, auxiliary_base_ring)
+A global Weierstrass model over a general base space
+
+julia> weierstrass_section_f(w)
+f
+```
+"""
+@attr MPolyElem{fmpq} weierstrass_section_f(w::WeierstrassModelOverGeneralBaseSpace) = w.f
+export weierstrass_section_f
+
+
+@doc Markdown.doc"""
+    weierstrass_section_g(w::WeierstrassModelOverGeneralBaseSpace)
+
+Return the Weierstrass section ``g``.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (f, g) = QQ["f", "g"];
+
+julia> w = GlobalWeierstrassModel(f, g, auxiliary_base_ring)
+A global Weierstrass model over a general base space
+
+julia> weierstrass_section_g(w)
+g
+```
+"""
+@attr MPolyElem{fmpq} weierstrass_section_g(w::WeierstrassModelOverGeneralBaseSpace) = w.g
+export weierstrass_section_g
+
+
+#######################################
+# 2: The Weierstrass polynomial
+#######################################
+
+@doc Markdown.doc"""
+    weierstrass_polynomial(w::WeierstrassModelOverGeneralBaseSpace)
+
+Return the Weierstrass polynomial.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (f, g) = QQ["f", "g"];
+
+julia> w = GlobalWeierstrassModel(f, g, auxiliary_base_ring)
+A global Weierstrass model over a general base space
+
+julia> weierstrass_polynomial(w)
+f*x*z^4 + g*z^6 + x^3 - y^2
+```
+"""
+@attr MPolyElem{fmpq} weierstrass_polynomial(w::WeierstrassModelOverGeneralBaseSpace) = w.pw
+export weierstrass_polynomial
+
+
+#######################################
+# 3: Auxiliary toric spaces
+#######################################
+
+@doc Markdown.doc"""
+    auxiliary_base_space(w::WeierstrassModelOverGeneralBaseSpace)
+
+Return the toric base space of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (f, g) = QQ["f", "g"];
+
+julia> w = GlobalWeierstrassModel(f, g, auxiliary_base_ring)
+A global Weierstrass model over a general base space
+
+julia> auxiliary_base_space(w)
+A normal, affine, 2-dimensional toric variety
+```
+"""
+@attr Oscar.AbstractNormalToricVariety auxiliary_base_space(w::WeierstrassModelOverGeneralBaseSpace) = w.auxiliary_base_space
+export auxiliary_base_space
+
+
+@doc Markdown.doc"""
+    auxiliary_ambient_space(w::WeierstrassModelOverGeneralBaseSpace)
+
+Return the toric ambient space of the global Tate model.
+
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (f, g) = QQ["f", "g"];
+
+julia> w = GlobalWeierstrassModel(f, g, auxiliary_base_ring)
+A global Weierstrass model over a general base space
+
+julia> auxiliary_ambient_space(w)
+A normal toric variety
+```
+"""
+@attr Oscar.AbstractNormalToricVariety auxiliary_ambient_space(w::WeierstrassModelOverGeneralBaseSpace) = w.auxiliary_ambient_space
+export auxiliary_ambient_space

--- a/src/WeierstrassModelsOverGeneralBaseSpace/constructors.jl
+++ b/src/WeierstrassModelsOverGeneralBaseSpace/constructors.jl
@@ -1,0 +1,124 @@
+######################################################
+# 1: The Julia type for WeierstrassModelOverGeneralBaseSpace
+######################################################
+
+@attributes mutable struct WeierstrassModelOverGeneralBaseSpace
+    f::MPolyElem_dec{fmpq, fmpq_mpoly}
+    g::MPolyElem_dec{fmpq, fmpq_mpoly}
+    pw::MPolyElem_dec{fmpq, fmpq_mpoly}
+    auxiliary_base_space::Oscar.AbstractNormalToricVariety
+    auxiliary_ambient_space::Oscar.AbstractNormalToricVariety
+    # TODO: Once new Oscar release is available
+    #Y4::Oscar.ClosedSubvarietyOfToricVariety
+    function WeierstrassModelOverGeneralBaseSpace(f::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                                  g::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                                  pw::MPolyElem_dec{fmpq, fmpq_mpoly},
+                                                  auxiliary_base_space::Oscar.AbstractNormalToricVariety,
+                                                  auxiliary_ambient_space::Oscar.AbstractNormalToricVariety)
+                                                  # TODO: Once new Oscar release is available
+                                                  #Y4::Oscar.ClosedSubvarietyOfToricVariety)
+        return new(f, g, pw, auxiliary_base_space, auxiliary_ambient_space)
+    end
+end
+export WeierstrassModelOverGeneralBaseSpace
+
+
+#######################################
+# 2: Generic constructor
+#######################################
+
+@doc Markdown.doc"""
+    GlobalWeierstrassModel(f::fmpq_mpoly, g::fmpq_mpoly, auxiliary_base_ring::MPolyRing)
+
+This method constructs a global Weierstrass model over a base space that is not
+fully specified. The following example illustrates this approach.
+
+# Examples
+```jldoctest
+julia> using Oscar
+
+julia> auxiliary_base_ring, (f, g) = QQ["f", "g"];
+
+julia> w = GlobalWeierstrassModel(f, g, auxiliary_base_ring)
+A global Weierstrass model over a general base space
+
+julia> weierstrass_polynomial(w)
+f*x*z^4 + g*z^6 + x^3 - y^2
+
+julia> auxiliary_base_space(w)
+A normal, affine, 2-dimensional toric variety
+
+julia> auxiliary_ambient_space(w)
+A normal toric variety
+
+julia> dim(auxiliary_ambient_space(w))
+4
+```
+"""
+function GlobalWeierstrassModel(f::fmpq_mpoly, g::fmpq_mpoly, auxiliary_base_ring::MPolyRing)
+
+    # Check if the base space is 3-dimensional
+    if (parent(f) != auxiliary_base_ring) || (parent(g) != auxiliary_base_ring)
+        throw(ArgumentError("All Weierstrass sections must reside in the provided auxiliary base ring"))
+    end
+
+    # Construct auxiliary base space
+    auxiliary_base_space = affine_space(NormalToricVariety, length(gens(auxiliary_base_ring)))
+    set_coordinate_names(auxiliary_base_space, [string(k) for k in gens(auxiliary_base_ring)])
+
+    # Extract information about the auxiliary toric base space
+    base_rays = matrix(ZZ,rays(auxiliary_base_space))
+    base_cones = matrix(ZZ, ray_indices(maximal_cones(auxiliary_base_space)))
+
+    # Construct the rays for the fibre ambient space
+    xray = [0 for i in 1:ncols(base_rays)+2]
+    yray = [0 for i in 1:ncols(base_rays)+2]
+    zray = [0 for i in 1:ncols(base_rays)+2]
+    xray[ncols(base_rays)+1] = 1
+    yray[ncols(base_rays)+2] = 1
+    zray[ncols(base_rays)+1] = -2
+    zray[ncols(base_rays)+2] = -3
+
+    # Construct the rays of the auxiliary toric ambient space
+    ambient_space_rays = hcat([r for r in base_rays], [-2 for i in 1:nrows(base_rays)], [-3 for i in 1:nrows(base_rays)])
+    ambient_space_rays = vcat(ambient_space_rays, transpose(xray), transpose(yray), transpose(zray))
+
+    # Construct the incidence matrix for the maximal cones of the ambient space
+    ambient_space_max_cones = []
+    for i in 1:nrows(base_cones)
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 1 0])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [1 0 1])])
+        push!(ambient_space_max_cones, [k for k in hcat([b for b in base_cones[i,:]], [0 1 1])])
+    end
+    ambient_space_max_cones = IncidenceMatrix(vcat(ambient_space_max_cones...))
+
+    # Construct the ambient space and perform consistency check
+    auxiliary_ambient_space = NormalToricVariety(PolyhedralFan(ambient_space_rays, ambient_space_max_cones; non_redundant = true))
+    set_coordinate_names(auxiliary_ambient_space, vcat([string(k) for k in gens(auxiliary_base_ring)], ["x", "y", "z"]))
+    S2 = cox_ring(auxiliary_ambient_space)
+
+    # Compute the Tate polynomial
+    ring_map = hom(auxiliary_base_ring, S2, [gens(S2)[i] for i in 1:length(gens(auxiliary_base_ring))])
+    x = gens(S2)[length(gens(S2))-2]
+    y = gens(S2)[length(gens(S2))-1]
+    z = gens(S2)[length(gens(S2))]
+    pw = x^3 - y^2 + ring_map(f)*x*z^4 + ring_map(g)*z^6
+
+    # TODO: Compute the toric hypersurface
+    # TODO: Once new Oscar release is available
+    #Y4 = Oscar.ClosedSubvarietyOfToricVariety(auxiliary_ambient_space, [pt])
+
+    # Return the global Weierstrass model
+    return WeierstrassModelOverGeneralBaseSpace(ring_map(f), ring_map(g), pw, auxiliary_base_space, auxiliary_ambient_space)
+
+end
+export GlobalWeierstrassModel
+
+
+#######################################
+# 3: Display
+#######################################
+
+function Base.show(io::IO, w::WeierstrassModelOverGeneralBaseSpace)
+    join(io, "A global Weierstrass model over a general base space")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,21 +4,21 @@ using Oscar
 
 
 #############################################################
-# 1: Compute fibrations
+# 1: Compute base space for explicit fibrations
 #############################################################
 
 test_space = hirzebruch_surface(2) * projective_space(NormalToricVariety,1)
 test_space1 = blowup_on_ith_minimal_torus_orbit(test_space,1,"e1")
 test_space2 = blowup_on_ith_minimal_torus_orbit(test_space1,1,"e2")
 base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
-t = GenericGlobalTateModel(base)
-Base.show(t)
-w = GenericGlobalWeierstrassModel(base)
-Base.show(w)
+
 
 #############################################################
-# 1: Test global Weierstrass models
+# 2: Test global Weierstrass models
 #############################################################
+
+w = GenericGlobalWeierstrassModel(base)
+Base.show(w)
 
 @testset "Attributes of global Weierstrass models" begin
     @test parent(weierstrass_section_f(w)) == cox_ring(toric_ambient_space(w))
@@ -35,8 +35,11 @@ end
 
 
 #############################################################
-# 2: Test global Tate models
+# 3: Test global Tate models
 #############################################################
+
+t = GenericGlobalTateModel(base)
+Base.show(t)
 
 @testset "Attributes of global Tate models" begin
     @test parent(tate_section_a1(t)) == cox_ring(toric_ambient_space(t))
@@ -50,6 +53,36 @@ end
     @test is_smooth(toric_ambient_space(t)) == false
 end
 
-@testset "Error messages in global Weierstrass models" begin
+@testset "Error messages in global Tate models" begin
     @test_throws ArgumentError GenericGlobalTateModel(hirzebruch_surface(1))
+end
+
+
+#############################################################
+# 4: Test global Tate models over generic base space
+#############################################################
+
+auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"]
+a1 = a10
+a2 = a21 * w
+a3 = a32 * w^2
+a4 = a43 * w^3
+a6 = a65 * w^5
+ais = [a1, a2, a3, a4, a6]
+t2 = GlobalTateModel(ais, auxiliary_base_ring)
+
+@testset "Attributes of global Tate models over generic base spaces" begin
+    @test parent(tate_section_a1(t2)) == cox_ring(auxiliary_ambient_space(t2))
+    @test parent(tate_section_a2(t2)) == cox_ring(auxiliary_ambient_space(t2))
+    @test parent(tate_section_a3(t2)) == cox_ring(auxiliary_ambient_space(t2))
+    @test parent(tate_section_a4(t2)) == cox_ring(auxiliary_ambient_space(t2))
+    @test parent(tate_section_a6(t2)) == cox_ring(auxiliary_ambient_space(t2))
+    @test parent(tate_polynomial(t2)) == cox_ring(auxiliary_ambient_space(t2))
+    @test dim(auxiliary_base_space(t2)) == 6
+    @test dim(auxiliary_ambient_space(t2)) == 8
+    @test is_smooth(auxiliary_ambient_space(t2)) == false
+end
+
+@testset "Error messages in global Tate models over generic base space" begin
+    @test_throws ArgumentError GlobalTateModel([a1], auxiliary_base_ring)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,9 +21,9 @@ Base.show(w)
 #############################################################
 
 @testset "Attributes of global Weierstrass models" begin
-    @test parent(poly_f(w)) == cox_ring(toric_ambient_space(w))
-    @test parent(poly_g(w)) == cox_ring(toric_ambient_space(w))
-    @test parent(pw(w)) == cox_ring(toric_ambient_space(w))
+    @test parent(weierstrass_section_f(w)) == cox_ring(toric_ambient_space(w))
+    @test parent(weierstrass_section_g(w)) == cox_ring(toric_ambient_space(w))
+    @test parent(weierstrass_polynomial(w)) == cox_ring(toric_ambient_space(w))
     @test dim(toric_base_space(w)) == 3
     @test dim(toric_ambient_space(w)) == 5
     @test is_smooth(toric_ambient_space(w)) == false
@@ -39,12 +39,12 @@ end
 #############################################################
 
 @testset "Attributes of global Tate models" begin
-    @test parent(a1(t)) == cox_ring(toric_ambient_space(t))
-    @test parent(a2(t)) == cox_ring(toric_ambient_space(t))
-    @test parent(a3(t)) == cox_ring(toric_ambient_space(t))
-    @test parent(a4(t)) == cox_ring(toric_ambient_space(t))
-    @test parent(a6(t)) == cox_ring(toric_ambient_space(t))
-    @test parent(pt(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(tate_section_a1(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(tate_section_a2(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(tate_section_a3(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(tate_section_a4(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(tate_section_a6(t)) == cox_ring(toric_ambient_space(t))
+    @test parent(tate_polynomial(t)) == cox_ring(toric_ambient_space(t))
     @test dim(toric_base_space(t)) == 3
     @test dim(toric_ambient_space(t)) == 5
     @test is_smooth(toric_ambient_space(t)) == false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ base = blowup_on_ith_minimal_torus_orbit(test_space2,1,"e3")
 
 
 #############################################################
-# 2: Test global Weierstrass models
+# 2: Global Weierstrass models
 #############################################################
 
 w = GenericGlobalWeierstrassModel(base)
@@ -35,7 +35,29 @@ end
 
 
 #############################################################
-# 3: Test global Tate models
+# 3: Global Weierstrass models over generic base space
+#############################################################
+
+auxiliary_base_ring, (f, g) = QQ["f", "g"]
+auxiliary_ring2, (x, y) = QQ["x", "y"]
+w2 = GlobalWeierstrassModel(f, g, auxiliary_base_ring)
+
+@testset "Attributes of global Weierstrass models over generic base spaces" begin
+    @test parent(weierstrass_section_f(w2)) == cox_ring(auxiliary_ambient_space(w2))
+    @test parent(weierstrass_section_g(w2)) == cox_ring(auxiliary_ambient_space(w2))
+    @test parent(weierstrass_polynomial(w2)) == cox_ring(auxiliary_ambient_space(w2))
+    @test dim(auxiliary_base_space(w2)) == 2
+    @test dim(auxiliary_ambient_space(w2)) == 4
+    @test is_smooth(auxiliary_ambient_space(w2)) == false
+end
+
+@testset "Error messages in global Weierstrass models over generic base space" begin
+    @test_throws ArgumentError GlobalWeierstrassModel(f, x^2, auxiliary_base_ring)
+end
+
+
+#############################################################
+# 4: Global Tate models
 #############################################################
 
 t = GenericGlobalTateModel(base)
@@ -59,7 +81,7 @@ end
 
 
 #############################################################
-# 4: Test global Tate models over generic base space
+# 5: Global Tate models over generic base space
 #############################################################
 
 auxiliary_base_ring, (a10,a21,a32,a43,a65,w) = QQ["a10", "a21", "a32", "a43", "a65", "w"]


### PR DESCRIPTION
This adds the desired functionality for Weierstrass and Tate models over non (or at least not fully) specified base spaces.

This PR also addresses the following:
- Link to documentation broken,
- Oscar must be installed for this package, and so the installation instructions were extended,
- Structure of the documentation adjusted to the extended content.

One other important change is to rename some functions. Thus far, the Tate sections could be accessed via `a1(t)` for a global Tate model `t`. This has the drawback that then the variable `a1` can no longer be given a specified value once `FTheoryTools` is loaded in a `julia` session. Similar for `pt` to access the Tate polynomial and `pw` for the Weierstrass polynomial. So this PR changes the names:
- `tate_section_a1(t)` instead of `a1(t)`,
- `tate_polynomial(t)` instead of `pt(t)`,
- `weierstrass_polynomial(t)` instead of `pw(w)`.

cc @apturner