### PR TITLE
Add Kodaira and refined Tate fiber types

### DIFF
--- a/src/TateModels/attributes.jl
+++ b/src/TateModels/attributes.jl
@@ -257,7 +257,7 @@ export discriminant
     singular_loci(t::GlobalTateModel)
 
 Return the singular loci of the global Tate model, along with the order of
-vanishing of ``(f, g, \Delta)`` at each locus.
+vanishing of ``(f, g, \Delta)``` at each locus and the refined Tate fiber type.
 
 For the time being, we either explicitly or implicitly focus on toric varieties
 as base spaces. Explicitly, in case the user provides such a variety as base space,
@@ -314,8 +314,8 @@ julia> length(singular_loci(t))
 2
 
 julia> singular_loci(t)[2]
-(ideal(w), (1, 2, 3))
+(ideal(w), (1, 2, 3), "III")
 ```
 """
-@attr Vector{Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, Tuple{Int64, Int64, Int64}}} singular_loci(t::GlobalTateModel) = singular_loci(global_weierstrass_model(t))
+@attr Vector{Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, Tuple{Int64, Int64, Int64}, String}} singular_loci(t::GlobalTateModel) = singular_loci(global_weierstrass_model(t))
 export singular_loci

--- a/src/WeierstrassModels/attributes.jl
+++ b/src/WeierstrassModels/attributes.jl
@@ -170,7 +170,7 @@ export discriminant
     singular_loci(w::GlobalWeierstrassModel)
 
 Return the singular loci of the global Weierstrass model, along with the order of
-vanishing of ``(f, g, \Delta)`` at each locus.
+vanishing of ``(f, g, \Delta)`` at each locus and the refined Tate fiber type.
 
 For the time being, we either explicitly or implicitly focus on toric varieties
 as base spaces. Explicitly, in case the user provides such a variety as base space,
@@ -233,10 +233,10 @@ julia> length(singular_loci(weier))
 2
 
 julia> singular_loci(weier)[2]
-(ideal(w), (1, 2, 3))
+(ideal(w), (1, 2, 3), "III")
 ```
 """
-@attr Vector{Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, Tuple{Int64, Int64, Int64}}} function singular_loci(w::GlobalWeierstrassModel)
+@attr Vector{Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, Tuple{Int64, Int64, Int64}, String}} function singular_loci(w::GlobalWeierstrassModel)
     B = irrelevant_ideal(toric_base_space(w))
 
     d_primes = primary_decomposition(ideal([discriminant(w)]))
@@ -250,7 +250,7 @@ julia> singular_loci(weier)[2]
     f_primes = primary_decomposition(ideal([w.poly_f]))
     g_primes = primary_decomposition(ideal([w.poly_g]))
 
-    kodaira_types = Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, Tuple{Int64, Int64, Int64}}[]
+    kodaira_types = Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, Tuple{Int64, Int64, Int64}, String}[]
     for d_prime in nontrivial_d_primes
         f_index = findfirst(fp -> fp[2] == d_prime[2], f_primes)
         g_index = findfirst(gp -> gp[2] == d_prime[2], g_primes)
@@ -258,8 +258,9 @@ julia> singular_loci(weier)[2]
         f_order = !isnothing(f_index) ? saturation_with_index(f_primes[f_index][1], d_prime[2])[2] : 0
         g_order = !isnothing(g_index) ? saturation_with_index(g_primes[g_index][1], d_prime[2])[2] : 0
         d_order = saturation_with_index(d_prime[1], d_prime[2])[2]
+        ords = (f_order, g_order, d_order)
 
-        push!(kodaira_types, (d_prime[2], (f_order, g_order, d_order)))
+        push!(kodaira_types, (d_prime[2], ords, _kodaira_type(d_prime[2], w.poly_f, w.poly_g, discriminant(w), ords)))
     end
     
     return kodaira_types

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -118,3 +118,94 @@ function TestBase()
     return NormalToricVariety(PolyhedralFan(rays, cones))
 end
 export TestBase
+
+################################################################
+# 6: Compute singularity Kodaira type and refined Tate type
+################################################################
+
+# TODO 1: The below assumes that the singular locus is given by
+#         a single coordinate
+# TODO 2: This code multiplies out an overall coefficient to better check for perfect squares,
+#         but can't properly factor cubics over the complexes, hence the ambiguity for I^*_0.
+#         An alternative approach for squares is to factor and then look at the values of the
+#         resulting dictionary
+function _kodaira_type(id::MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, f::MPolyElem{fmpq}, g::MPolyElem{fmpq}, d::MPolyElem{fmpq}, ords::Tuple{Int64, Int64, Int64})
+    f_ord = ords[1]
+    g_ord = ords[2]
+    d_ord = ords[3]
+
+    poly_f = f.f
+    poly_g = g.f
+    poly_d = d.f
+    locus = id.gens[1].f
+
+    if d_ord == 0
+        kod_type = "I_0"
+    elseif d_ord == 1 && f_ord == 0 && g_ord == 0
+        kod_type = "I_1"
+    elseif f_ord == 0 && g_ord == 0
+        monodromy_poly = divexact(evaluate(9 * poly_g, [locus], [0]), evaluate(2 * poly_f, [locus], [0]))
+        monodromy_poly *= monodromy_poly.content_den // monodromy_poly.content_num
+        if is_square(monodromy_poly)
+            kod_type = "Split I_$d_ord"
+        else
+            kod_type = "Non-split I_$d_ord"
+        end
+    elseif d_ord == 2 && g_ord == 1 && f_ord >= 1
+        kod_type = "II"
+    elseif d_ord == 3 && f_ord == 1 && g_ord >= 2
+        kod_type = "III"
+    elseif d_ord == 4 && g_ord == 2 && f_ord >= 2
+        monodromy_poly = evaluate(divexact(poly_g, locus^2), [locus], [0])
+        monodromy_poly *= monodromy_poly.content_den // monodromy_poly.content_num
+        if is_square(monodromy_poly)
+            kod_type = "Split IV"
+        else
+            kod_type = "Non-split IV"
+        end
+    elseif d_ord == 6 && f_ord >= 2 && g_ord >= 3
+        # Using locus here is a trick to avoid defining a new polynomial ring
+        # It probably won't work once the issue of locus being a single coordinate is addressed
+        monodromy_poly =  locus^3 + locus * evaluate(divexact(poly_f, locus^2), [locus], [0]) + evaluate(divexact(poly_g, locus^3), [locus], [0])
+        num_facs = length(factor(monodromy_poly).fac)
+        if num_facs == 3
+            kod_type = "Split I^*_0"
+        elseif num_facs == 2
+            kod_type = "Semi-split or split I^*_0"
+        else
+            kod_type = "Non-split, semi-split, or split I^*_0"
+        end
+    elseif f_ord == 2 && g_ord == 2 && d_ord >= 7 && d_ord % 2 == 1
+        monodromy_poly = evaluate(divexact(poly_d, locus^d_ord) * divexact(evaluate(divexact(2 * poly_f, locus^2), [locus], [0]), evaluate(divexact(9 * poly_g, locus^3), [locus], [0]))^3, [locus], [0]) / 4
+        monodromy_poly *= monodromy_poly.content_den // monodromy_poly.content_num
+        if is_square(monodromy_poly)
+            kod_type = "Split I^*_$(d_ord - 2)"
+        else
+            kod_type = "Non-split I^*_$(d_ord - 2)"
+        end
+    elseif f_ord == 2 && g_ord == 2 && d_ord >= 8 && d_ord % 2 == 0
+        monodromy_poly = evaluate(divexact(poly_d, locus^d_ord) * divexact(evaluate(divexact(2 * poly_f, locus^2), [locus], [0]), evaluate(divexact(9 * poly_g, locus^3), [locus], [0]))^2, [locus], [0])
+        monodromy_poly *= monodromy_poly.content_den // monodromy_poly.content_num
+        if is_square(monodromy_poly)
+            kod_type = "Split I^*_$(d_ord - 2)"
+        else
+            kod_type = "Non-split I^*_$(d_ord - 2)"
+        end
+    elseif d_ord == 8 && g_ord == 4 && f_ord >= 3
+        monodromy_poly = evaluate(divexact(poly_g, locus^4), [locus], [0])
+        monodromy_poly *= monodromy_poly.content_den // monodromy_poly.content_num
+        if is_square(monodromy_poly)
+            kod_type = "Split IV^*"
+        else
+            kod_type = "Non-split IV^*"
+        end
+    elseif d_ord == 9 && f_ord == 3 && g_ord >= 5
+        kod_type = "III^*"
+    elseif d_ord == 10 && g_ord == 5 && f_ord >= 4
+        kod_type = "II^*"
+    elseif d_ord >= 12 && f_ord >= 4 && g_ord >= 6
+        kod_type = "Non-minimal"
+    end
+    
+    return kod_type
+end


### PR DESCRIPTION
Adds the refined Tate fiber type to `singular_loci`. Currently has two issues:
1. Currently only works if the singular locus is given by the vanishing of a single coordinate, e.g., w = 0
2. Cannot fully distinguish split, semi-split, and non-split I^*_0 fibers