### PR TITLE
Improve the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ We base this project on [OSCAR](https://oscar.computeralgebra.de/) for general f
 ```
 5. To use your `FTheoryTools` installation, you finally want to invoke
 ```julia
-    using("Oscar")
-    using("FTheoryTools")
+    using Oscar, FTheoryTools
 ```
 
 Note that due to the modularity of the `Julia` programing language, access to the `Oscar`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,8 +57,7 @@ We base this project on [OSCAR](https://oscar.computeralgebra.de/) for general f
 ```
 5. To use your `FTheoryTools` installation, you finally want to invoke
 ```julia
-    using("Oscar")
-    using("FTheoryTools")
+    using Oscar, FTheoryTools
 ```
 
 Note that due to the modularity of the `Julia` programing language, access to the `Oscar`


### PR DESCRIPTION
Replace `using("Oscar")` by `using Oscar` (and alike for `using("FTheoryTools")`).