### PR TITLE
Add first version of blowup code

### DIFF
--- a/src/WeierstrassModels/attributes.jl
+++ b/src/WeierstrassModels/attributes.jl
@@ -242,7 +242,7 @@ julia> singular_loci(weier)[2]
     d_primes = primary_decomposition(ideal([discriminant(w)]))
     nontrivial_d_primes = Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}}[]
     for k in 1:length(d_primes)
-        if !(is_one(d_primes[k][2]) || is_one(saturation(d_primes[k][2], B)))
+        if _is_nontrivial(d_primes[k][2], B)
             push!(nontrivial_d_primes, d_primes[k])
         end
     end

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -125,6 +125,7 @@ export test_base
 ################################################################
 
 # TODO: The below assumes that the singular locus is given by a single coordinate
+# Only works for codimension 1
 
 _count_factors(poly::fmpq_mpoly) = mapreduce(p -> p[end], +, absolute_primary_decomposition(ideal([poly])))
 
@@ -207,4 +208,71 @@ function _kodaira_type(id::MPolyIdeal{T}, f::T, g::T, d::T, ords::Tuple{Int64, I
     end
     
     return kod_type
-end 
+end
+
+
+################################################################
+# 7: Blowups
+################################################################
+
+function _blowup_ideal(id::MPolyIdeal{T}, center_gens::Vector{T}, irr::MPolyIdeal{T}, sri::MPolyIdeal{T}, lin::MPolyIdeal{U}; index::Integer = 1) where {T,U<:MPolyElem{fmpq}}
+    @warn "The function _blowup_ideal is experimental; absence of bugs and proper results are not guaranteed"
+
+    id_gens = gens(id)
+    R = base_ring(id)
+
+    if any(g -> parent(g) != R, center_gens)
+        throw(ArgumentError("The generators of the blowup center must reside in the parent ring of the given ideal"))
+    end
+
+    if base_ring(irr) != R
+        throw(ArgumentError("The given irrelevant ideal must share the parent ring of the given ideal"))
+    end
+    if base_ring(sri) != R
+        throw(ArgumentError("The given Stanley–Reisner ideal must share the parent ring of the given ideal"))
+    end
+    # if base_ring(lin) != R.R # Replace with getter function once it exists
+    #     throw(ArgumentError("The given ideal of linear relations must share the (underlying ungraded) parent ring of the given ideal"))
+    # end
+
+    S, S_gens = PolynomialRing(QQ, [string("e_", index); [string("b_", index, "_", i) for i in 1:length(center_gens)]; [string(v) for v in gens(R)]], cached = false)
+    (_e, new_gs...) = S_gens[1:length(center_gens) + 1]
+    ring_map = hom(R, S, S_gens[length(center_gens) + 2:end])
+    
+    result_id = ideal([[ring_map(poly) for poly in id_gens]; [g * _e - center_gen for (g, center_gen) in zip(new_gs, map(ring_map, center_gens))]])
+
+    result_irr = ideal([ring_map(gens(irr)[i]) * new_gs[j] for i in 1:length(gens(irr)) for j in 1:length(new_gs)])
+    result_sri = ideal([map(ring_map, gens(sri)); prod(new_gs)])
+    result_lin = lin
+
+    return result_id, result_irr, result_sri, result_lin, S, S_gens
+end
+export _blowup_ideal
+
+function _blowup_ideal_sequence(id::MPolyIdeal{T}, centers::Vector{<:Vector{<:Integer}}, irr::MPolyIdeal{T}, sri::MPolyIdeal{T}, lin::MPolyIdeal{U}; index::Integer = 1, proper::Bool = true) where {T,U<:MPolyElem{fmpq}}
+    @warn "The function _blowup_ideal_sequence is experimental; absence of bugs and proper results are not guaranteed"
+
+    (cur_ids, cur_irr, cur_sri, cur_lin, cur_S, cur_S_gens, cur_index) = ([id], irr, sri, lin, nothing, gens(base_ring((id))), index)
+
+    for center in centers
+        if !(all(ind -> 1 <= ind <= length(cur_S_gens), center))
+            throw(ArgumentError("The given indices for the center generators are out of bounds"))
+        end
+
+        next_ids = MPolyIdeal{<:MPolyElem{fmpq}}[]
+        for cur_id in cur_ids
+            (next_id, cur_irr, cur_sri, cur_lin, cur_S, cur_S_gens) = _blowup_ideal(cur_id, map(ind -> cur_S_gens[ind], center), cur_irr, cur_sri, cur_lin, index = cur_index)
+            all_ids = map(pair -> pair[2], primary_decomposition(next_id))
+            append!(next_ids, filter(id -> !(cur_S_gens[1] in gens(id)), all_ids))
+        end
+
+        cur_ids = next_ids
+        cur_index += 1
+    end
+
+    return cur_ids, cur_irr, cur_sri, cur_lin, cur_S, cur_S_gens
+end
+export _blowup_ideal_sequence
+
+_is_nontrivial(id::MPolyIdeal{T}, irr::MPolyIdeal{T}) where {T<:MPolyElem{fmpq}} = !(is_one(id)) && !(is_one(saturation(id, irr)))
+export _is_nontrivial

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,4 +231,12 @@ end
     @test singular_loci(t_nm)[1][2:3] == ((4, 6, 12), "Non-minimal")
 end
 
-
+@testset "Blowups" begin
+    id_i5_s = ideal([tate_polynomial(t_i5_s)]);
+    tas = t_i5_s.toric_ambient_space;
+    irr_i5_s = irrelevant_ideal(tas);
+    sri_i5_s = stanley_reisner_ideal(tas);
+    lin_i5_s = ideal_of_linear_relations(tas);
+    id_fin, _, _, _, _, _ = _blowup_ideal_sequence(id_i5_s, [[7, 8, 6], [2, 3, 1], [3, 4], [2, 4]], irr_i5_s, sri_i5_s, lin_i5_s)
+    @test string(gens(id_fin[1])[end - 3]) == "b_4_1*b_2_1*a1p*z + b_4_1*b_2_2 + b_4_1*b_2_3*b_1_3^2*a3p*z^3 - b_4_2*b_3_2*b_2_1^2*b_1_1 - b_4_2*b_3_2*b_2_1^2*b_1_3*a2p*z^2 - b_4_2*b_3_2*b_2_1*b_2_3*b_1_3^3*a4p*z^4 - b_4_2*b_3_2*b_2_3^2*b_1_3^5*a6p*z^6"
+end


### PR DESCRIPTION
This is still experimental. The code works and produces the expected results for the SU(5) Tate model.

- The function `_blowup_ideal` carries out a single blowup
- ~~The function `_blowup_ideal_post` carries out a single blowup using a different ordering of the variables, and results in a significantly increased runtime compared with `_blowup_ideal`~~ Function removed
- The function `_blowup_ideal_sequence` carries out a sequence of blowups, attempting to take the proper transform at each stage. The result agrees with the one you get by hand using `_blowup_ideal` for the SU(5) Tate model

I suspect that `_blowup_ideal_sequence` will fail to work when the locus in question splits into multiple reducible parts after the blowup, although the intention is for it to be set up to handle that. The reason is that each ideal is blown up separately, producing separate irrelevant and SR ideals each time. Although these are all equal, they are different objects as far as OSCAR is concerned and so it will throw an error.