### PR TITLE
Improve blowup code and add rudimentary codimension-one fiber analysis

### DIFF
--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -8,3 +8,11 @@ then run [bibtool](http://www.gerd-neugebauer.de/software/TeX/BibTool/en/)
 by invoking it as follows from the root directory of the Oscar.jl repository:
 
     bibtool docs/references.bib -o docs/references.bib
+
+# To-Dos
+* The irrelevant ideal, SR ideal, and ideal of linear relations may need to be modified when the exceptional coordinate "e" is included in the blowup. They are currently set up to work when e is eliminated
+* Decide whether to stick with global blowups or use charts
+* Consolidate notation about sections and line bundles in the documentation
+* The Kodaira type function assumes that the singular locus is given by a single coordinate
+* The Kodaira type function only works for codimension 1
+* Modify the _ambient_space_from_base function to return ring maps from the base to the ambient space and all other constructors/types to appropriately carry that around, then fix the corresponding bit of code in analyze_fibers

--- a/docs/src/tate.md
+++ b/docs/src/tate.md
@@ -14,15 +14,15 @@ A global Tate model describes a particular form of an elliptic fibration.
 We focus on elliptic fibrations over base 3-folds ``B3``. Consider
 the weighted projective space ``\mathbb{P}^{2,3,1}`` with coordinates
 ``x, y, z``. In addition, consider
-- ``a_1 \in H^0( B_3, \overline{K}_{B_3} )``,
-- ``a_2 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 2} )``,
-- ``a_3 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 3} )``,
-- ``a_4 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
-- ``a_6 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``.
+* ``a_1 \in H^0( B_3, \overline{K}_{B_3} )``,
+* ``a_2 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 2} )``,
+* ``a_3 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 3} )``,
+* ``a_4 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
+* ``a_6 \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``.
 Then form a ``\mathbb{P}^{2,3,1}``-bundle over ``B3`` such that
-- ``x`` transforms as a section of ``2 \overline{K}_{B_3}``,
-- ``y`` transforms as a section of ``3 \overline{K}_{B_3}``,
-- ``z`` transforms as a section of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
+* ``x`` transforms as a section of ``2 \overline{K}_{B_3}``,
+* ``y`` transforms as a section of ``3 \overline{K}_{B_3}``,
+* ``z`` transforms as a section of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
 In this 5-fold ambient space, a global Tate model is the hypersurface defined
 by the vanishing of the Tate polynomial
 ``P_T = x^3 - y^2 - x y z a_1 + x^2 z^2 a_2 - y z^3 a_3 + x z^4 a_4 + z^6 a_6``.
@@ -54,11 +54,11 @@ the backbone of many F-theory constructions.
 To this end, this method accepts a polynomial ring whose variables are the sections
 used in the desired factorization of the Tate sections ``a_i``. For example, if we
 desired a factorization:
-- ``a_1 = a_{10} w^0``,
-- ``a_2 = a_{21} w^1``,
-- ``a_3 = a_{32} w^2``,
-- ``a_4 = a_{43} w^3``,
-- ``a_6 = a_{65} w^5``,
+* ``a_1 = a_{10} w^0``,
+* ``a_2 = a_{21} w^1``,
+* ``a_3 = a_{32} w^2``,
+* ``a_4 = a_{43} w^3``,
+* ``a_6 = a_{65} w^5``,
 then the polynomial ring in question is the ring with indeterminates
 ``a_{10}``, ``a_{21}``, ``a_{32}``, ``a_{43}``, ``a_{65}`` and ``w``.
 

--- a/docs/src/weierstrass.md
+++ b/docs/src/weierstrass.md
@@ -14,12 +14,12 @@ A global Weierstrass model describes a particular form of an elliptic fibration.
 We focus on elliptic fibrations over base 3-folds ``B3``. Consider
 the weighted projective space ``\mathbb{P}^{2,3,1}`` with coordinates
 ``x, y, z``. In addition, consider
-- ``f \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
-- ``g \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``,
+* ``f \in H^0( B_3, \overline{K}_{B_3}^{\otimes 4} )``,
+* ``g \in H^0( B_3, \overline{K}_{B_3}^{\otimes 6} )``,
 Then form a ``\mathbb{P}^{2,3,1}``-bundle over ``B3`` such that
-- ``x`` transforms as a section of ``2 \overline{K}_{B_3}``,
-- ``y`` transforms as a section of ``3 \overline{K}_{B_3}``,
-- ``z`` transforms as a section of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
+* ``x`` transforms as a section of ``2 \overline{K}_{B_3}``,
+* ``y`` transforms as a section of ``3 \overline{K}_{B_3}``,
+* ``z`` transforms as a section of ``0 \overline{K}_{B_3} = \mathcal{O}_{B_3}``.
 In this 5-fold ambient space, a global Weierstrass model is the hypersurface defined
 by the vanishing of the Weierstrass polynomial ``P_W = x^3 - y^2 + f x z^4 + g z^6``.
 

--- a/src/TateModels/attributes.jl
+++ b/src/TateModels/attributes.jl
@@ -319,3 +319,66 @@ julia> singular_loci(t)[2]
 """
 @attr Vector{Tuple{MPolyIdeal{MPolyElem_dec{fmpq, fmpq_mpoly}}, Tuple{Int64, Int64, Int64}, String}} singular_loci(t::GlobalTateModel) = singular_loci(global_weierstrass_model(t))
 export singular_loci
+
+#####################################################
+# 7: Fiber analysis
+#####################################################
+
+function analyze_fibers(model::GlobalTateModel, centers::Vector{<:Vector{<:Integer}})
+    # Ideal of the defining polynomial
+    hypersurface_ideal = ideal([tate_polynomial(model)])
+
+    # Toric ambient space
+    tas = toric_ambient_space(model)
+
+    # Various important ideals
+    irr = irrelevant_ideal(tas);
+    sri = stanley_reisner_ideal(tas);
+    lin = ideal_of_linear_relations(tas);
+
+    # Singular loci
+    sing_loc = singular_loci(model)
+
+    # Pick out the singular loci that are more singular than an I_1
+    # Then keep only the locus and not the extra info about it
+    interesting_singular_loci = map(tup -> tup[1], filter(locus -> locus[2][3] > 1, sing_loc))
+
+    # This is a kludge to map polynomials on the base into the ambient space, and should be fixed once the ambient space constructors supply such a map
+    base_coords = parent(gens(interesting_singular_loci[1])[1])
+    ambient_coords = parent(tate_polynomial(model))
+    base_to_ambient_ring_map = hom(base_coords, ambient_coords, gens(ambient_coords)[1:end-3])
+
+    # Resolved model
+    strict_transform, exceptionals, crepant, res_irr, res_sri, res_lin, res_S, res_S_gens, res_ring_map = _blowup_global_sequence(hypersurface_ideal, centers, irr, sri, lin)
+    if !crepant
+        @warn "The given sequence of blowups is not crepant"
+    end
+
+    loci_fiber_intersections = Tuple{MPolyIdeal{fmpq_mpoly}, Vector{Tuple{Tuple{Int64, Int64}, Vector{MPolyIdeal{fmpq_mpoly}}}}}[]
+    for locus in interesting_singular_loci
+        # Currently have to get the ungraded ideal generators by hand using .f
+        ungraded_locus = ideal(map(gen -> base_to_ambient_ring_map(gen).f, gens(locus)))
+
+        # Potential components of the fiber over this locus
+        # For now, we only consider the associated prime ideal,
+        #   but we may later want to actually consider the primary ideals
+        potential_components = map(pair -> pair[2], primary_decomposition(strict_transform + res_ring_map(ungraded_locus)))
+
+        # Filter out the trivial loci among the potential components
+        components = filter(component -> _is_nontrivial(component, res_irr), potential_components)
+
+        # Check the pairwise intersections of the components
+        intersections = Tuple{Tuple{Int64, Int64}, Vector{MPolyIdeal{fmpq_mpoly}}}[]
+        for i in 1:length(components) - 1
+            for j in i + 1:length(components)
+                intersection = filter(candidate_locus -> _is_nontrivial(candidate_locus, res_irr), map(pair -> pair[2], primary_decomposition(components[i] + components[j])))
+                push!(intersections, ((i, j), intersection))
+            end
+        end
+
+        push!(loci_fiber_intersections, (ungraded_locus, intersections))
+    end
+
+    return loci_fiber_intersections
+end
+export analyze_fibers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,6 +237,11 @@ end
     irr_i5_s = irrelevant_ideal(tas);
     sri_i5_s = stanley_reisner_ideal(tas);
     lin_i5_s = ideal_of_linear_relations(tas);
-    id_fin, _, _, _, _, _ = _blowup_ideal_sequence(id_i5_s, [[7, 8, 6], [2, 3, 1], [3, 4], [2, 4]], irr_i5_s, sri_i5_s, lin_i5_s)
-    @test string(gens(id_fin[1])[end - 3]) == "b_4_1*b_2_1*a1p*z + b_4_1*b_2_2 + b_4_1*b_2_3*b_1_3^2*a3p*z^3 - b_4_2*b_3_2*b_2_1^2*b_1_1 - b_4_2*b_3_2*b_2_1^2*b_1_3*a2p*z^2 - b_4_2*b_3_2*b_2_1*b_2_3*b_1_3^3*a4p*z^4 - b_4_2*b_3_2*b_2_3^2*b_1_3^5*a6p*z^6"
+    id_fin,  = _blowup_global_sequence(id_i5_s, [[7, 8, 6], [2, 3, 1], [3, 4], [2, 4]], irr_i5_s, sri_i5_s, lin_i5_s)
+    @test string(gens(id_fin)[end]) == "-b_4_1*b_2_1*a1p*z - b_4_1*b_2_2 - b_4_1*b_2_3*b_1_3^2*a3p*z^3 + b_4_2*b_3_2*b_2_1^2*b_1_1 + b_4_2*b_3_2*b_2_1^2*b_1_3*a2p*z^2 + b_4_2*b_3_2*b_2_1*b_2_3*b_1_3^3*a4p*z^4 + b_4_2*b_3_2*b_2_3^2*b_1_3^5*a6p*z^6"
+end
+
+@testset "Fibers" begin
+    inters = analyze_fibers(t_i5_s, [[7, 8, 6], [2, 3, 1], [3, 4], [2, 4]])
+    @test string(inters[1][2][1][2][1]) == "ideal(e_2*b_2_1 - b_1_1, b_3_1*a1p*z - b_3_2*b_1_1^2, b_4_1*a1p*z - b_4_2*b_3_2*b_2_1*b_1_1, b_4_1*b_1_1 - b_4_2*b_3_1*b_2_1, b_4_1*e_2 - b_4_2*b_3_1, e_4*b_4_2 - e_2, e_4*b_4_1 - b_3_1, y, x, v, b_1_3, b_1_2, e_1, b_2_3, b_2_2, e_3)"
 end


### PR DESCRIPTION
Improves the blowup code and adds a simple function to compute the intersection pattern of the codimension-one fiber components. The latter should be improved in the future.